### PR TITLE
Add contact sensor state option for garage doors

### DIFF
--- a/ADVANCED_OPTIONS.md
+++ b/ADVANCED_OPTIONS.md
@@ -20,6 +20,7 @@ Before configuring, you may need to:
 - `category` - **optional**: Device category code. See [SUPPORTED_DEVICES.md](./SUPPORTED_DEVICES.md). Also you can use `hidden` to hide the device, product, or scene. **⚠️Overriding this property may lead to unexpected behaviors and exceptions, so please remove the accessory cache after making changes.**
 - `unbridged` - **optional**: Unbridge accessories. Defaults to `false`.
 - `adaptiveLighting` - **optional**: Adaptive Lighting. Defaults to `false`. Not all light device support this feature, please use it on demand.
+- `garageDoorUseContactSensorForState` - **optional**: For garage door controllers. When `true`, `CurrentDoorState` and `TargetDoorState` reads use `doorcontact_state` only, while set commands still use `switch_1`. Defaults to `false`.
 - `schema` - **optional**: An array of schema overriding config objects, used for describing datapoint (DP). When your device has non-standard DP, you need to transform them manually with configuration. Each element in the schema array is described as follows:
   - `code` - **required**: DP code.
   - `newCode` - **optional**: New DP code.
@@ -89,6 +90,22 @@ An example of hide camera's floodlight (`floodlight_switch`):
     "deviceOverrides": [{
       "id": "{device_id}",
       "adaptiveLighting": true
+    }]
+  }
+}
+```
+
+### Use garage door contact sensor for state
+
+Some `ckmkzq` garage door controllers keep `switch_1` as `true`, which can make HomeKit show the door as stuck Opening or Closing. Enable this per-device option to read the door state from `doorcontact_state`, while commands are still sent to `switch_1`.
+
+```js
+{
+  "options": {
+    // ...
+    "deviceOverrides": [{
+      "id": "{device_id}",
+      "garageDoorUseContactSensorForState": true
     }]
   }
 }

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Before you can configure, you must go to the [Tuya IoT Platform](https://iot.tuy
 #### Advanced options
 See [ADVANCED_OPTIONS.md](./ADVANCED_OPTIONS.md)
 
+Garage door controllers that keep `switch_1=true` can opt in to contact-sensor-only state reads with `garageDoorUseContactSensorForState` in `options.deviceOverrides`. This keeps commands on `switch_1`, but reads HomeKit state from `doorcontact_state`.
+
 
 ## Limitations
 - **⚠️Don't forget to extend the API trial period every 6 months. Maybe you can set up a reminder in calendar.**

--- a/config.schema.json
+++ b/config.schema.json
@@ -140,6 +140,14 @@
                                         "functionBody": "return (model.options && model.options.deviceOverrides);"
                                     }
                                 },
+                                "garageDoorUseContactSensorForState": {
+                                    "title": "Use Contact Sensor For Garage Door State",
+                                    "description": "For garage door controllers only. Derive CurrentDoorState and TargetDoorState reads from doorcontact_state instead of switch_1.",
+                                    "type": "boolean",
+                                    "condition": {
+                                        "functionBody": "return (model.options && model.options.deviceOverrides);"
+                                    }
+                                },
                                 "schema": {
                                     "title": "Schema Overriding Configs",
                                     "type": "array",
@@ -424,6 +432,9 @@
                                 },
                                 {
                                     "key": "options.deviceOverrides[].unbridged"
+                                },
+                                {
+                                    "key": "options.deviceOverrides[].garageDoorUseContactSensorForState"
                                 },
                                 {
                                     "key": "options.deviceOverrides[].schema",

--- a/src/accessory/GarageDoorAccessory.ts
+++ b/src/accessory/GarageDoorAccessory.ts
@@ -12,15 +12,17 @@ export default class GarageDoorAccessory extends BaseAccessory {
   }
 
   configureServices() {
-
     this.configureCurrentDoorState();
     this.configureTargetDoorState();
   }
 
-
   mainService() {
     return this.accessory.getService(this.Service.GarageDoorOpener)
       || this.accessory.addService(this.Service.GarageDoorOpener);
+  }
+
+  useContactSensorForState() {
+    return this.platform.getDeviceConfig(this.device)?.garageDoorUseContactSensorForState === true;
   }
 
   configureCurrentDoorState() {
@@ -28,13 +30,23 @@ export default class GarageDoorAccessory extends BaseAccessory {
     this.mainService().getCharacteristic(this.Characteristic.CurrentDoorState)
       .onGet(() => {
         const currentSchema = this.getSchema(...SCHEMA_CODE.CURRENT_DOOR_STATE);
-        const targetSchema = this.getSchema(...SCHEMA_CODE.TARGET_DOOR_STATE);
-        if (!currentSchema || !targetSchema) {
+        if (!currentSchema) {
           return STOPPED;
         }
 
         const currentStatus = this.getStatus(currentSchema.code)!;
+
+        if (this.useContactSensorForState()) {
+          return currentStatus.value === false ? CLOSED : OPEN;
+        }
+
+        const targetSchema = this.getSchema(...SCHEMA_CODE.TARGET_DOOR_STATE);
+        if (!targetSchema) {
+          return STOPPED;
+        }
+
         const targetStatus = this.getStatus(targetSchema.code)!;
+
         if (currentStatus.value === true && targetStatus.value === true) {
           return OPEN;
         } else if (currentStatus.value === false && targetStatus.value === false) {
@@ -58,6 +70,17 @@ export default class GarageDoorAccessory extends BaseAccessory {
     const { OPEN, CLOSED } = this.Characteristic.TargetDoorState;
     this.mainService().getCharacteristic(this.Characteristic.TargetDoorState)
       .onGet(() => {
+        if (this.useContactSensorForState()) {
+          const currentSchema = this.getSchema(...SCHEMA_CODE.CURRENT_DOOR_STATE);
+
+          if (!currentSchema) {
+            return CLOSED;
+          }
+
+          const currentStatus = this.getStatus(currentSchema.code)!;
+          return currentStatus.value === false ? CLOSED : OPEN;
+        }
+
         const status = this.getStatus(schema.code)!;
         return status.value as boolean ? OPEN : CLOSED;
       })

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export interface TuyaPlatformDeviceConfig {
   schema?: Array<TuyaPlatformDeviceSchemaConfig>;
   unbridged?: boolean;
   adaptiveLighting?: boolean;
+  garageDoorUseContactSensorForState?: boolean;
 }
 
 export interface TuyaPlatformServiceInformationConfig {


### PR DESCRIPTION
Adds an opt-in per-device setting for ckmkzq garage doors where switch_1 remains true persistently.

When garageDoorUseContactSensorForState is enabled:
- CurrentDoorState is derived from doorcontact_state
- TargetDoorState mirrors doorcontact_state
- commands still use switch_1
- default behavior is unchanged

Build passes. Full test suite has existing local-config-dependent failures when ~/.homebridge-dev/config.json is not present.