### PR TITLE
fix(local): apply typed schema overrides without rename and guard status reads

### DIFF
--- a/src/local/LocalDeviceManager.ts
+++ b/src/local/LocalDeviceManager.ts
@@ -137,8 +137,18 @@ export default class LocalDeviceManager extends TuyaDeviceManager {
   }
 
   override getDeviceSchemaConfig(device: TuyaDevice, dpCode: string) {
-    const schemaConfig = this.getDeviceConfig(device)?.schema?.find(s => s.code === dpCode);
-    return schemaConfig;
+    const schema = this.getDeviceConfig(device)?.schema;
+    if (!schema || !dpCode) {
+      return undefined;
+    }
+
+    // ignore case - allow both the device code and its (optional) rename
+    const target = dpCode.toString().toLowerCase();
+    return schema.find(s => {
+      const code = s.code?.toString().toLowerCase();
+      const newCode = s.newCode?.toString().toLowerCase();
+      return code === target || newCode === target;
+    });
   }
 
   override enableGarageDoorUseContactSensorForState(device: TuyaDevice): boolean {
@@ -509,7 +519,9 @@ export default class LocalDeviceManager extends TuyaDeviceManager {
     // override dpcodes
     for (const [dpCode, dpID] of Object.entries(effectiveMap)) {
       const schemaConfig = this.getDeviceSchemaConfig({ id: cfg.tuyaDeviceId} as any, dpCode);
-      if (!!schemaConfig && !!schemaConfig.newCode) {
+      // Only treat newCode as a rename when it actually differs from the device code.
+      // Renaming to the same key would set-then-delete it, dropping the dp↔code mapping.
+      if (schemaConfig?.newCode && schemaConfig.newCode !== dpCode) {
         effectiveMap[schemaConfig.newCode] = dpID;
         delete effectiveMap[dpCode];
       }
@@ -759,15 +771,20 @@ export default class LocalDeviceManager extends TuyaDeviceManager {
       property: {},
     }) as TuyaDeviceSchema);
 
-    // apply overrides
+    // apply overrides. The synthetic schemas are keyed on the (possibly renamed)
+    // dp code, so match on newCode when a rename is set, otherwise on the device code.
     this.getDeviceConfig(device)?.schema?.forEach(s => {
-      const schema = schemas.find(t => t.code === s.newCode);
+      const targetCode = s.newCode ?? s.code;
+      if (!targetCode) {
+        return;
+      }
+      const schema = schemas.find(t => t.code === targetCode);
       if (!!schema) {
         schema.type = s.type ?? schema.type;
         schema.property = s.property ?? schema.property;
       } else {
         schemas.push({
-          code: s.newCode!,
+          code: targetCode,
           mode: TuyaDeviceSchemaMode.READ_WRITE,
           type: s.type ?? TuyaDeviceSchemaType.Boolean,
           property: s.property ?? {},

--- a/src/shared/accessory/characteristic/CurrentRelativeHumidity.ts
+++ b/src/shared/accessory/characteristic/CurrentRelativeHumidity.ts
@@ -18,7 +18,10 @@ export function configureCurrentRelativeHumidity(accessory: BaseAccessory, servi
   const multiple = Math.pow(10, property['scale'] || 0);
   service.getCharacteristic(accessory.Characteristic.CurrentRelativeHumidity)
     .onGet(() => {
-      const status = accessory.getStatus(schema.code)!;
+      const status = accessory.getStatus(schema.code);
+      if (!status) {
+        return props['minValue'] ?? 0;
+      }
       return limit(status.value as number / multiple, props['minValue'], props['maxValue']);
     })
     .setProps(props);

--- a/src/shared/accessory/characteristic/LockPhysicalControls.ts
+++ b/src/shared/accessory/characteristic/LockPhysicalControls.ts
@@ -10,7 +10,10 @@ export function configureLockPhysicalControls(accessory: BaseAccessory, service:
   const { CONTROL_LOCK_DISABLED, CONTROL_LOCK_ENABLED } = accessory.Characteristic.LockPhysicalControls;
   service.getCharacteristic(accessory.Characteristic.LockPhysicalControls)
     .onGet(() => {
-      const status = accessory.getStatus(schema.code)!;
+      const status = accessory.getStatus(schema.code);
+      if (!status) {
+        return CONTROL_LOCK_DISABLED;
+      }
       return (status.value as boolean) ? CONTROL_LOCK_ENABLED : CONTROL_LOCK_DISABLED;
     })
     .onSet(async value => {

--- a/src/shared/accessory/characteristic/RelativeHumidityDehumidifierThreshold.ts
+++ b/src/shared/accessory/characteristic/RelativeHumidityDehumidifierThreshold.ts
@@ -19,7 +19,10 @@ export function configureRelativeHumidityDehumidifierThreshold(accessory: BaseAc
 
   service.getCharacteristic(accessory.Characteristic.RelativeHumidityDehumidifierThreshold)
     .onGet(() => {
-      const status = accessory.getStatus(schema.code)!;
+      const status = accessory.getStatus(schema.code);
+      if (!status) {
+        return props.minValue;
+      }
       return limit(status.value as number / multiple, 0, 100);
     })
     .onSet(async value => {

--- a/src/shared/accessory/characteristic/SwingMode.ts
+++ b/src/shared/accessory/characteristic/SwingMode.ts
@@ -10,7 +10,10 @@ export function configureSwingMode(accessory: BaseAccessory, service: Service, s
   const { SWING_DISABLED, SWING_ENABLED } = accessory.Characteristic.SwingMode;
   service.getCharacteristic(accessory.Characteristic.SwingMode)
     .onGet(() => {
-      const status = accessory.getStatus(schema.code)!;
+      const status = accessory.getStatus(schema.code);
+      if (!status) {
+        return SWING_DISABLED;
+      }
       return (status.value as boolean) ? SWING_ENABLED : SWING_DISABLED;
     })
     .onSet(async (value) => {


### PR DESCRIPTION
## Summary

Fixes local-mode (LAN) handling of per-device schema overrides and hardens several characteristic read handlers. Without these changes a Tuya dehumidifier (category `cs`) cannot expose correct **current humidity** / **target humidity** in HomeKit on the local protocol, and the child bridge can crash in a restart loop.

Fixes #36

## Root cause

Local mode's override matching diverged from the cloud manager, and there was **no config-only way to apply a typed (e.g. `Integer`) override to an existing DP** in local mode:

- `LocalDeviceManager.getDeviceSchemaConfig` matched on `code` only (case-sensitive) and ignored `newCode`, unlike `TuyaCloudDeviceManager` which matches `code` **or** `newCode` case-insensitively.
- `_registerDeviceConfig` renamed the dp map key whenever `newCode` was truthy — so a no-op rename (`newCode === code`) did `set` then `delete` on the **same** key, dropping the dp↔code mapping entirely. The DP was then never routed and `getStatus(code)` returned `undefined`.
- `_buildSyntheticSchema` matched/pushed overrides by `s.newCode`. With no rename it matched nothing and pushed a `{ code: undefined }` schema entry, which then crashed `BaseAccessory.getSchema` at `schema.code.toLowerCase()` — taking down the whole child bridge.
- Several characteristic read handlers used `accessory.getStatus(schema.code)!.value` with no guard, throwing `Cannot read properties of undefined (reading 'value')` whenever a DP had not been received yet (e.g. at startup before the device connects).

## Changes

- **`LocalDeviceManager.getDeviceSchemaConfig`** — match overrides by `code` **or** `newCode`, case-insensitive, consistent with the cloud manager.
- **`_registerDeviceConfig`** — only treat `newCode` as a rename when `newCode && newCode !== dpCode`, so a no-op rename no longer set-then-deletes the mapping.
- **`_buildSyntheticSchema`** — match/apply overrides by `newCode ?? code` and skip entries with no code, so a no-rename typed override lands on the correct synthetic schema and a code-less entry is never pushed.
- **`CurrentRelativeHumidity` / `RelativeHumidityDehumidifierThreshold` / `SwingMode` / `LockPhysicalControls`** — null-guard `getStatus()` in the read handlers; return a sane default when the DP hasn't been received yet instead of throwing.

With these fixes a typed override needs no `newCode` hack:

```json
{
  "id": "<deviceId>",
  "configFor": "local",
  "schema": [
    { "code": "humidity_indoor",     "type": "Integer", "property": { "min": 0, "max": 100, "scale": 0, "step": 1 } },
    { "code": "dehumidify_set_value", "type": "Integer", "property": { "min": 0, "max": 100, "scale": 0, "step": 5 } }
  ]
}
```

## Test plan

- [x] `npm run build` and `npm run lint` clean.
- [x] `npm test` — all 884 tests pass (2 pre-existing suite failures are unrelated: they require a local `~/.homebridge-dev/config.json`).
- [x] Verified on hardware: a local dehumidifier (protocol 3.3) now reports real current humidity (e.g. 30%) and target (25%) in HomeKit; no `toLowerCase` crash loop and no `Lock Physical Controls` / `Swing Mode` read errors at startup.

## Notes

The unguarded `getStatus(...)!.value` pattern exists in many other accessories/characteristics; this PR only guards the handlers exercised by the dehumidifier. A broader sweep could be done as a follow-up.

Made with [Cursor](https://cursor.com)