### PR TITLE
fix(fan): normalize four-level speed percentages

### DIFF
--- a/src/accessory/characteristic/RotationSpeed.ts
+++ b/src/accessory/characteristic/RotationSpeed.ts
@@ -1,5 +1,10 @@
 import { Service } from 'homebridge';
-import { TuyaDeviceSchema, TuyaDeviceSchemaEnumProperty, TuyaDeviceSchemaIntegerProperty } from '../../device/TuyaDevice';
+import {
+  TuyaDeviceSchema,
+  TuyaDeviceSchemaEnumProperty,
+  TuyaDeviceSchemaIntegerProperty,
+  TuyaDeviceSchemaType,
+} from '../../device/TuyaDevice';
 import { limit } from '../../util/util';
 import BaseAccessory from '../BaseAccessory';
 
@@ -14,6 +19,16 @@ export function configureRotationSpeed(
   }
 
   const property = schema.property as TuyaDeviceSchemaIntegerProperty;
+  if (schema.code === 'fan_speed_percent'
+    && schema.type === TuyaDeviceSchemaType.Integer
+    && property.min === 1
+    && property.max === 4
+    && property.scale === 0
+    && property.step === 1) {
+    configureFourLevelRotationSpeed(accessory, service, schema);
+    return;
+  }
+
   const multiple = Math.pow(10, property.scale);
   const props = {
     minValue: property.min / multiple,
@@ -32,6 +47,32 @@ export function configureRotationSpeed(
     })
     .setProps(props);
 
+}
+
+function configureFourLevelRotationSpeed(
+  accessory: BaseAccessory,
+  service: Service,
+  schema: TuyaDeviceSchema,
+) {
+  const props = { minValue: 0, maxValue: 100, minStep: 25 };
+  const onGetHandler = () => {
+    const status = accessory.getStatus(schema.code)!;
+    const level = limit(Math.round(Number(status.value)), 1, 4);
+    return level * 25;
+  };
+
+  service.getCharacteristic(accessory.Characteristic.RotationSpeed)
+    .onGet(onGetHandler)
+    .onSet(async value => {
+      const percent = Number(value);
+      if (!Number.isFinite(percent) || percent <= 0) {
+        return;
+      }
+      const level = limit(Math.round(percent / 25), 1, 4);
+      await accessory.sendCommands([{ code: schema.code, value: level }], true);
+    })
+    .updateValue(onGetHandler())
+    .setProps(props);
 }
 
 export function configureRotationSpeedLevel(

--- a/test/accessory/rotationSpeed.test.ts
+++ b/test/accessory/rotationSpeed.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import BaseAccessory from '../../src/accessory/BaseAccessory';
+import { configureRotationSpeed } from '../../src/accessory/characteristic/RotationSpeed';
+import { TuyaDeviceSchemaMode, TuyaDeviceSchemaType } from '../../src/device/TuyaDevice';
+
+describe('configureRotationSpeed', () => {
+  test('maps four-level fan_speed_percent values to HomeKit percentages', async () => {
+    let rawLevel = 1;
+    let getHandler: () => number = () => 0;
+    let setHandler: (value: number) => Promise<void> = async () => undefined;
+    const characteristic = {
+      onGet: jest.fn((handler: () => number) => {
+        getHandler = handler;
+        return characteristic;
+      }),
+      onSet: jest.fn((handler: (value: number) => Promise<void>) => {
+        setHandler = handler;
+        return characteristic;
+      }),
+      updateValue: jest.fn(() => characteristic),
+      setProps: jest.fn(() => characteristic),
+    };
+    const service = {
+      getCharacteristic: jest.fn(() => characteristic),
+    };
+    const sendCommands = jest.fn(async () => undefined);
+    const accessory = {
+      Characteristic: { RotationSpeed: 'RotationSpeed' },
+      getStatus: jest.fn(() => ({ code: 'fan_speed_percent', value: rawLevel })),
+      sendCommands,
+    } as unknown as BaseAccessory;
+    const schema = {
+      code: 'fan_speed_percent',
+      mode: TuyaDeviceSchemaMode.READ_WRITE,
+      type: TuyaDeviceSchemaType.Integer,
+      property: { min: 1, max: 4, scale: 0, step: 1, unit: '' },
+    };
+
+    configureRotationSpeed(accessory, service as never, schema);
+
+    expect(characteristic.setProps).toHaveBeenCalledWith({ minValue: 0, maxValue: 100, minStep: 25 });
+    expect(characteristic.updateValue).toHaveBeenCalledWith(25);
+    expect([1, 2, 3, 4].map(level => {
+      rawLevel = level;
+      return getHandler();
+    })).toEqual([25, 50, 75, 100]);
+
+    for (const [percent, level] of [[25, 1], [50, 2], [75, 3], [100, 4]]) {
+      await setHandler(percent);
+      expect(sendCommands).toHaveBeenLastCalledWith(
+        [{ code: 'fan_speed_percent', value: level }],
+        true,
+      );
+    }
+
+    await setHandler(0);
+    expect(sendCommands).toHaveBeenCalledTimes(4);
+  });
+});


### PR DESCRIPTION
## Summary

Normalize four-level Tuya `fan_speed_percent` devices to HomeKit's percentage-based Rotation Speed contract.

## What Changed

- Detect the exact integer schema `min: 1`, `max: 4`, `scale: 0`, `step: 1` for `fan_speed_percent`.
- Advertise Rotation Speed as `0-100%` with a `25%` step.
- Map HomeKit `25/50/75/100%` to Tuya levels `1/2/3/4` and map device updates back symmetrically.
- Add a focused regression test covering both directions and the zero-speed guard.

## Why

Some Tuya fans expose discrete levels under a DP named `fan_speed_percent`. Passing the raw `1-4` bounds directly to HomeKit mixes discrete levels with percentage semantics, producing incorrect displayed values and preventing HomeKit from reliably selecting the highest level.

This was reproduced and physically validated on an OmniBreeze tower fan. The fix is intentionally limited to the exact four-level schema; other integer and enum speed schemas retain their current behavior.

Refs #38.

## Validation

- Focused Jest regression test: passed.
- ESLint for the changed source and test: passed with zero warnings.
- TypeScript build: passed.
- Physical Home app validation: `25/50/75/100%` selected fan levels `1/2/3/4`.
- Full Jest run: 44 tests passed; `home.test.ts` and `custom.test.ts` could not initialize because they require a local `~/.homebridge-dev/config.json` fixture.

## Risks / Notes

- The new behavior only activates for `fan_speed_percent` with the exact `1-4` integer schema.
- Existing users who previously overrode this schema will need to remove that override and clear the accessory cache so HomeKit receives the new characteristic metadata.

## Reviewer Focus

- Symmetry of the percentage-to-level conversion.
- Whether the exact schema guard is appropriately narrow.
- HomeKit characteristic metadata ordering when restoring cached accessories.
