### PR TITLE
fix: preserve non-numbered switch codes during DP filtering

### DIFF
--- a/src/local/LocalDeviceManager.ts
+++ b/src/local/LocalDeviceManager.ts
@@ -830,19 +830,22 @@ export default class LocalDeviceManager extends TuyaDeviceManager {
       filteredMapping = {};
       const switchCodes: string[] = [];
       for (const [code, dp] of Object.entries(dpMapping)) {
-        // Keep non-switch DPs (brightness, temp, color, etc.)
-        if (!code.startsWith('switch')) {
-          filteredMapping[code] = dp;
-        }
-        // For switches, only include switch_1..switch_N
         const switchMatch = code.match(/^switch_(\d+)$/);
+
         if (switchMatch) {
           const switchNum = parseInt(switchMatch[1], 10);
+
           if (switchNum <= switchCount) {
             filteredMapping[code] = dp;
             switchCodes.push(code);
           }
+
+          continue;
         }
+
+        // Non-numbered switch codes such as switch_fan, switch_led,
+        // switch_horizontal, etc. are preserved.
+        filteredMapping[code] = dp;
       }
       if (switchCodes.length < Object.keys(dpMapping).filter(k => k.startsWith('switch')).length) {
         this.log.debug(`Filtered switches: kept [${switchCodes.join(', ')}], excluded others`);


### PR DESCRIPTION
## :recycle: Current situation

The local device DP mapping filters switch codes based on `switchCount`.

Previously, the filtering logic only treated numbered switch codes such as `switch_1`, `switch_2`, etc. as switch channels:

```ts
if (!code.match(/^switch_(\d+)$/)) {
  filteredMapping[code] = dp;
}
```

This allowed non-numbered switch DP codes such as switch_fan, switch_led, and switch_horizontal to remain in the mapping.

However, the newer filtering logic treats every DP whose code starts with switch as a switch channel. This causes valid non-numbered switch codes to be incorrectly filtered out when switchCount is enabled.

For example, a local fan may have the following mapping:
```
{
  "switch_fan": 1,
  "fan_speed": 3
}
```
With switchCount = 1, switch_fan is not a numbered switch (switch_1), but it can still be incorrectly filtered out.

As a result, the device schema no longer contains the required switch_fan DP, causing the device to be detected as unsupported and preventing the fan accessory from being properly configured.

## :bulb: Proposed solution

Update the switch filtering logic so that only numbered switch codes matching switch_<number> are subject to switchCount filtering.

Non-numbered switch codes and other DP codes are preserved.

The filtering logic now explicitly distinguishes numbered switches:
```ts
for (const [code, dp] of Object.entries(dpMapping)) {
  const switchMatch = code.match(/^switch_(\d+)$/);

  if (switchMatch) {
    const switchNum = parseInt(switchMatch[1], 10);

    if (switchNum <= switchCount) {
      filteredMapping[code] = dp;
      switchCodes.push(code);
    }

    continue;
  }

  // Preserve non-numbered switch codes and other DPs.
  filteredMapping[code] = dp;
}
```

This preserves mappings such as:
- switch_fan
- switch_led
- switch_horizontal

while still correctly limiting numbered switches:
- switch_1
- switch_2
- switch_3
- etc.

No changes to the public configuration format are required.

## :gear: Release Notes

Fix an issue where valid non-numbered Tuya switch DP codes could be incorrectly removed from local device mappings.

This primarily affects devices such as fans and other appliances that use DP codes such as switch_fan instead of numbered switch codes (switch_1, switch_2, etc.).

No configuration changes are required.

## :heavy_plus_sign: Additional Information

_If applicable, provide additional context in this section._

### Testing

The change was tested with a Tuya local tower fan using the following DP mapping:
```ts
{
  "switch_fan": 1,
  "fan_speed": 3
}
```
The device uses:

- `switch_fan` for power control
- `fan_speed` for speed control

With the previous filtering behavior, switch_fan could be excluded from the resulting mapping, causing the fan to be reported as unsupported.

After the change, the mapping is preserved correctly:
```ts
{
  "switch_fan": 1,
  "fan_speed": 3
}
```

The fan accessory is successfully registered and the power control works as expected.

The filtering behavior for numbered switches was also verified. For example, when switchCount = 2:
- `switch_1` is retained
- `switch_2` is retained
- `switch_3` is excluded
- `switch_fan` is retained
Other non-numbered DP codes are retained

Automated tests were not added for this change. Manual testing was performed against a physical Tuya tower fan.

Potential edge cases that could be covered by future tests include:
- `switch_1` through `switch_N`
- `switch_0`
- `switch_fan`
- `switch_led`
- `switch_horizontal`
Devices containing both numbered and non-numbered switch DPs

### Reviewer Nudging

A good entry point is the switch filtering logic in `LocalDeviceManager`.

Please review the handling of DP codes matching:

```
switch_<number>
```

versus other DP codes beginning with `switch`.

The main behavior to verify is that `switchCount` only limits numbered switch channels and does not remove valid non-numbered switch DPs such as `switch_fan`.
