### PR TITLE
Fix(WindowCovering): force STOPPED state at physical bounds for RF re…

### DIFF
--- a/src/accessory/WindowCoveringAccessory.ts
+++ b/src/accessory/WindowCoveringAccessory.ts
@@ -94,10 +94,10 @@ export default class WindowCoveringAccessory extends BaseAccessory {
         const targetStatus = this.getStatus(targetSchema.code)!;
 
         // Fix applied: Override for physical RF remote bounds check.
-        // If current position reaches hardware limits, force STOPPED state 
+        // If current position reaches hardware limits, force STOPPED state
         // to prevent UI freezing due to desynced targetStatus.
         if (currentStatus.value === 0 || currentStatus.value === 100) {
-           return STOPPED;
+          return STOPPED;
         }
 
         if (targetStatus.value === 100 && currentStatus.value !== 100) { // (B)

--- a/src/accessory/WindowCoveringAccessory.ts
+++ b/src/accessory/WindowCoveringAccessory.ts
@@ -87,17 +87,25 @@ export default class WindowCoveringAccessory extends BaseAccessory {
     service.getCharacteristic(this.Characteristic.PositionState)
       .onGet(() => {
         if (!currentSchema || !targetSchema) {
-          return STOPPED;
+          return STOPPED; // (A)
         }
 
         const currentStatus = this.getStatus(currentSchema.code)!;
         const targetStatus = this.getStatus(targetSchema.code)!;
-        if (targetStatus.value === 100 && currentStatus.value !== 100) {
+
+        // Fix applied: Override for physical RF remote bounds check.
+        // If current position reaches hardware limits, force STOPPED state 
+        // to prevent UI freezing due to desynced targetStatus.
+        if (currentStatus.value === 0 || currentStatus.value === 100) {
+           return STOPPED;
+        }
+
+        if (targetStatus.value === 100 && currentStatus.value !== 100) { // (B)
           return INCREASING;
-        } else if (targetStatus.value === 0 && currentStatus.value !== 0) {
+        } else if (targetStatus.value === 0 && currentStatus.value !== 0) { // (C)
           return DECREASING;
         } else {
-          return STOPPED;
+          return STOPPED; // (D)
         }
       });
   }


### PR DESCRIPTION
Some Tuya Zigbee tubular blind motors do not reliably update targetStatus in real-time when triggered via a physical RF remote. This mismatch causes the CurrentPosition and TargetPosition to desync, trapping the logic in an INCREASING or DECREASING return block indefinitely and freezing the Apple Home UI.

This fix adds a hardware limit bounds check: if currentStatus reaches 0% or 100%, the PositionState is forced to STOPPED, preventing the UI hang regardless of the delayed WebSocket payload.

Resolves #45

### ♻️ Current situation

When using a physical RF remote to control Tuya Zigbee tubular blind motors, the hardware immediately updates the `CurrentPosition` (to 0 or 100), but fails to update the `TargetPosition` in real-time. 

In `WindowCoveringAccessory.ts`, the logic inside `configurePositionState` assumes `targetStatus` is always accurate. Because of the mismatch, the logic evaluates `targetStatus !== currentStatus` and returns `INCREASING` or `DECREASING`, trapping the Apple Home app UI in a perpetual "Opening/Closing..." animation until the Tuya cloud eventually dispatches a delayed WebSocket payload.

### 💡 Proposed solution

Added a physical hardware bounds check to `configurePositionState`. 

Before comparing the target against the current state, the logic now checks if `currentStatus.value` has reached the physical limits (`0` or `100`). If it has, it immediately returns `STOPPED`. 

This prevents the desync caused by the RF remote from keeping the HomeKit UI frozen, without altering the behavior for normal app-triggered movements.

### ⚙️ Release Notes

* **Bug Fixes**
  * `WindowCovering`: Fixed an issue where the accessory would get stuck in the "Opening" or "Closing" state when operated externally via physical RF remotes due to delayed target state updates from the Tuya cloud.

### ➕ Additional Information

N/A

### Testing

I have locally deployed this fix via `homebridge-tuya` on my environment controlling a real Tuya Zigbee tubular blind (via physical remote, Apple Home app, and Tuya Smart app). 
* When triggering the blind via RF remote, the UI now correctly transitions to the "Open/Closed" stopped state as soon as the motor hits 0% or 100%.
* Normal operations via the Home app remain unaffected and work as intended.

### Reviewer Nudging

Reviewer can jump straight into `src/accessories/WindowCoveringAccessory.ts` -> `configurePositionState()`.