### PR TITLE
feat(TuyaPlatform): add ignoredDevices option to selectively exclude accessories

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -372,6 +372,14 @@
                         "title": "Forcing IPv4 connection",
                         "type": "boolean",
                         "default": false
+                    },
+                    "ignoredDevices": {
+                        "title": "Ignored Devices",
+                        "description": "List of Device IDs that should not be exported to HomeKit.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             },

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,7 @@ export interface TuyaPlatformCustomConfigOptions {
   debug?: boolean;
   debugLevel?: string;
   forceIPv4: boolean;
+  ignoredDevices?: string[];
 }
 
 export interface TuyaPlatformHomeConfigOptions {
@@ -62,6 +63,7 @@ export interface TuyaPlatformHomeConfigOptions {
   debug?: boolean;
   debugLevel?: string;
   forceIPv4: boolean;
+  ignoredDevices?: string[];
 }
 
 export interface RTSPCameraConfig {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -194,6 +194,10 @@ export class TuyaPlatform implements DynamicPlatformPlugin {
 
     // add accessories
     for (const device of devices) {
+      if (this.options?.ignoredDevices?.includes(device.id)) {
+        this.log.info(`Skipping ignored device: ${device.name} (${device.id})`);
+        continue;
+      }
       this.addAccessory(device);
     }
 


### PR DESCRIPTION
### ♻️ Current situation
Currently, the plugin fetches and exports all devices linked to the Tuya project into Apple HomeKit. There is no native way to filter out secondary switches, background automation modules, or devices managed exclusively via other platforms, causing unnecessary clutter in the Home app.

💡 Proposed solution
Added an ignoredDevices array parameter to the platform options in config.json. During the device discovery phase in platform.ts, the plugin now checks if the device.id exists in this array. If it does, it skips registering the accessory.

⚙️ Release Notes
Features

Added ignoredDevices configuration option to allow users to selectively exclude specific Tuya devices from being exported to HomeKit.