### PR TITLE
fix(local): make protocol 3.5 local mode work (0x6699 frame format, handshake watchdog, state polling)

### DIFF
--- a/src/local/LocalDevice.ts
+++ b/src/local/LocalDevice.ts
@@ -18,6 +18,14 @@ export interface LocalDeviceContext {
   name?: string;
   port?: number;
   pingGap?: number;
+  /** Seconds to wait for a heartbeat reply before counting it as missed (default 20) */
+  pingTimeout?: number;
+  /** Missed heartbeats tolerated before the socket is dropped (default 2) */
+  pingRetries?: number;
+  /** Seconds between state refreshes; 0 disables polling (default 60) */
+  pollGap?: number;
+  /** Seconds to wait for the v3.4/v3.5 key-exchange reply (default 15) */
+  handshakeTimeout?: number;
   connectTimeout?: number;
 }
 
@@ -59,6 +67,9 @@ export default class LocalDevice extends EventEmitter {
   private pinger?: ReturnType<typeof setTimeout>;
   private connTimeout?: ReturnType<typeof setTimeout>;
   private errorReconnect?: ReturnType<typeof setTimeout>;
+  private handshakeTimer?: ReturnType<typeof setTimeout>;
+  private poller?: ReturnType<typeof setTimeout>;
+  private missedPings = 0;
   private connectionAttempts = 0;
 
   constructor(
@@ -67,7 +78,7 @@ export default class LocalDevice extends EventEmitter {
     super();
     this.log = new PrefixLogger(logger(), `${(context.name || context.id)}(Local)`, false);
     this.context.port = this.context.port ?? 6668;
-    this.context.pingGap = this.context.pingGap ?? 9;
+    this.context.pingGap = this.context.pingGap ?? 25;
     this.context.connectTimeout = this.context.connectTimeout ?? 30;
     this.protocol = ProtocolFactory.createProtocol(context.version);
   }
@@ -233,6 +244,7 @@ export default class LocalDevice extends EventEmitter {
         this.emit('connect');
         this._schedulePing();
         this.queryState();
+        this._schedulePoll();
       }
     });
 
@@ -242,6 +254,25 @@ export default class LocalDevice extends EventEmitter {
         // Begin 3-way key exchange
         this.tmpLocalKey = crypto.randomBytes(16);
         this._send({ cmd: 3, data: this.tmpLocalKey, encrypted: true });
+
+        // Nothing else watches the handshake: connTimeout was just cleared, and the
+        // heartbeat/poll timers only start once a session key exists.  A device that
+        // accepts the TCP connection but never answers cmd 3 leaves the socket
+        // ESTABLISHED and unusable indefinitely (observed for 10 hours), with every
+        // command timing out and nothing in the log to explain it.
+        const handshakeSeconds = this.context.handshakeTimeout ?? 15;
+        this.handshakeTimer = setTimeout(() => {
+          this.handshakeTimer = undefined;
+          if (this.sessionKey) {
+            return;
+          }
+          this.log.warn(
+            `Key exchange unanswered within ${handshakeSeconds}s for ${this.context.name} `
+            + `(${this.context.ip}) – dropping the socket and reconnecting`,
+          );
+          sock.destroy();
+        }, handshakeSeconds * 1000);
+        this.handshakeTimer.unref?.();
       }
     });
 
@@ -270,6 +301,18 @@ export default class LocalDevice extends EventEmitter {
       this.sessionKey = undefined;
       this.emit('disconnect');
       this.socket = undefined;
+
+      // A close without a preceding 'error' (the device hung up, or we dropped the
+      // socket ourselves) had no reconnect path, leaving the device offline until the
+      // next rediscovery sweep.
+      if (!this.errorReconnect) {
+        const delay = Math.min(30000, 1000 * Math.min(this.connectionAttempts, 10));
+        this.errorReconnect = setTimeout(() => {
+          this.errorReconnect = undefined;
+          this._connect();
+        }, delay);
+        this.errorReconnect.unref?.();
+      }
     });
 
     sock.on('end', () => {
@@ -297,6 +340,12 @@ export default class LocalDevice extends EventEmitter {
   }
 
   private _clearTimers(): void {
+    if (this.handshakeTimer) {
+      clearTimeout(this.handshakeTimer); this.handshakeTimer = undefined;
+    }
+    if (this.poller) {
+      clearTimeout(this.poller); this.poller = undefined;
+    }
     if (this.pinger) {
       clearTimeout(this.pinger); this.pinger = undefined;
     }
@@ -313,8 +362,13 @@ export default class LocalDevice extends EventEmitter {
       clearTimeout(this.pinger);
       this.pinger = undefined;
     }
+    // Called on connect and on every heartbeat reply: the device is alive again.
+    this.missedPings = 0;
+    this._armPing();
+  }
 
-    const primaryDelay = (this.context.pingGap ?? 20) * 1000;
+  private _armPing(): void {
+    const primaryDelay = (this.context.pingGap ?? 25) * 1000;
     this.pinger = setTimeout(() => {
       this._send({ cmd: 9 });
 
@@ -322,14 +376,61 @@ export default class LocalDevice extends EventEmitter {
         clearTimeout(this.pinger);
       }
 
+      const waitSeconds = this.context.pingTimeout ?? 20;
       this.pinger = setTimeout(() => {
-        const msg = `ping timeout – no response within 5s for ${this.context.name} (${this.context.ip})`;
+        // Tolerate late replies.  A busy host or WiFi module can answer many seconds
+        // after the heartbeat, and dropping the socket on the first miss makes matters
+        // worse: the device holds on to the stale connection and runs out of the few
+        // slots it has, after which it stops answering anyone at all.
+        this.missedPings = (this.missedPings ?? 0) + 1;
+        const allowed = this.context.pingRetries ?? 2;
+        if (this.missedPings <= allowed) {
+          this.log.info(
+            `Heartbeat unanswered ${this.missedPings}/${allowed + 1} after ${waitSeconds}s `
+            + `for ${this.context.name} – retrying instead of reconnecting`,
+          );
+          this._armPing();
+          return;
+        }
+        const msg = `ping timeout – no response within ${waitSeconds}s over ${this.missedPings} tries `
+          + `for ${this.context.name} (${this.context.ip})`;
         this._reportError(new Error(msg));
-      }, 5000);
+      }, waitSeconds * 1000);
       this.pinger.unref?.();
     }, primaryDelay);
 
     this.pinger.unref?.();
+  }
+
+  /**
+   * Re-query the device state on a timer.
+   *
+   * Some devices (e.g. the Daikin WiFiKit-II-DK) never push DP updates, so the values
+   * captured by the initial query stay frozen for the lifetime of the connection –
+   * room temperature, on/off and mode included, which also means a change made with
+   * the physical remote is never noticed.  Devices that do push updates simply answer
+   * with the same values, so this is safe for every protocol version.
+   * Set `pollGap` to 0 to disable.
+   */
+  private _schedulePoll(): void {
+    if (this.poller) {
+      clearTimeout(this.poller);
+      this.poller = undefined;
+    }
+
+    const gapSeconds = this.context.pollGap ?? 60;
+    if (!gapSeconds) {
+      return;
+    }
+
+    this.poller = setTimeout(() => {
+      if (this.connected) {
+        this.queryState();
+      }
+      this._schedulePoll();
+    }, gapSeconds * 1000);
+
+    this.poller.unref?.();
   }
 
   // ── Private: frame parsing ────────────────────────────────────────────────
@@ -449,10 +550,17 @@ export default class LocalDevice extends EventEmitter {
       this.sessionKey = ciphertext.subarray(0, 16);
     }
 
+    if (this.handshakeTimer) {
+      clearTimeout(this.handshakeTimer);
+      this.handshakeTimer = undefined;
+    }
+
     this.connected = true;
+    this.log.info(`Local session established with ${this.context.name} (${this.context.ip})`);
     this._schedulePing();
     this.emit('connect');
     this.queryState();
+    this._schedulePoll();
   }
 
   /** @internal Used by gateway to propagate child state updates. */

--- a/src/local/protocol/ProtocolUtilities.ts
+++ b/src/local/protocol/ProtocolUtilities.ts
@@ -18,7 +18,7 @@
  *   unknown uint16 BE  0x0000
  *   seqno   uint32 BE
  *   cmd     uint32 BE
- *   length  uint32 BE  (bytes: IV(12) + ciphertext + GCM-tag(16) + suffix(4))
+ *   length  uint32 BE  (bytes: IV(12) + ciphertext + GCM-tag(16); the suffix is NOT counted)
  *   iv      12 bytes
  *   ciphertext variable
  *   tag     16 bytes
@@ -264,11 +264,16 @@ export function packMessage6699(
   plaintext: Buffer,
   hmacKey: Buffer,
 ): Buffer {
-  // Generate IV from current time (matches TinyTuya debug=False behaviour)
-  const iv = Buffer.from(String(Date.now() / 100).slice(0, 12).padStart(12, '0'), 'latin1');
+  // Random 12-byte GCM nonce (TinyTuya uses os.urandom(12)).  It travels inside the
+  // frame, so any unique value is wire-compatible; a time-derived nonce repeats for
+  // every message sent within the same 100 ms, which breaks GCM's uniqueness rule.
+  const iv = randomBytes(12);
 
   // header (18 bytes): prefix(4) + unknown(2) + seqno(4) + cmd(4) + length(4)
-  const length = 12 + plaintext.length + 16 + 4; // IV(12) + cipher(N) + tag(16) + suffix(4)
+  // The length field covers IV(12) + ciphertext(N) + tag(16) and NOT the 4-byte
+  // suffix (TinyTuya pack_message: len(payload) + (calcsize('>16sI') - 4) + 12).
+  // Counting the suffix here makes the device reject the frame without replying.
+  const length = 12 + plaintext.length + 16;
   const header = Buffer.allocUnsafe(HEADER_SIZE_6699);
   header.writeUInt32BE(PREFIX_6699, 0);
   header.writeUInt16BE(0x0000, 4);
@@ -296,10 +301,16 @@ export interface TuyaMessage6699 {
 
 /**
  * Unpack a complete 0x6699 frame.
+ *
+ * @param data      Full frame buffer (prefix through suffix inclusive)
+ * @param hmacKey   Session key, or the device key during key exchange
+ * @param noRetcode Set for frames produced on this side: device→client frames carry a
+ *                  4-byte retcode ahead of the payload, client→device frames do not
  */
 export function unpackMessage6699(
   data: Buffer,
   hmacKey: Buffer,
+  noRetcode = false,
 ): TuyaMessage6699 | null {
   if (data.length < HEADER_SIZE_6699 + 12 + 16 + 4) {
     return null;
@@ -312,7 +323,8 @@ export function unpackMessage6699(
   const cmd = data.readUInt32BE(10);
   const length = data.readUInt32BE(14);
 
-  const totalLen = HEADER_SIZE_6699 + length;
+  // `length` covers IV + ciphertext + tag; the 4-byte suffix follows it
+  const totalLen = HEADER_SIZE_6699 + length + 4;
   if (data.length < totalLen) {
     return null;
   }
@@ -331,8 +343,11 @@ export function unpackMessage6699(
     return null;
   }
 
-  // strip 4-byte retcode if present
-  if (payload.length >= 4 && payload[0] === 0 && payload[1] === 0) {
+  // Device→client 0x6699 frames always carry a 4-byte retcode ahead of the payload,
+  // and TinyTuya strips it unconditionally (unpack_message with no_retcode=False).
+  // Sniffing the first bytes instead mis-slices binary payloads: a key-exchange
+  // response starts with a random nonce, so it was stripped only ~1 time in 65536.
+  if (!noRetcode && payload.length >= 4) {
     payload = payload.subarray(4);
   }
 
@@ -359,7 +374,8 @@ export function isFrameComplete(buffer: Buffer): boolean {
       return false;
     }
     const length = buffer.readUInt32BE(14);
-    return buffer.length >= HEADER_SIZE_6699 + length;
+    // `length` excludes the 4-byte suffix
+    return buffer.length >= HEADER_SIZE_6699 + length + 4;
   }
   return false;
 }
@@ -402,7 +418,9 @@ export function extractFrame(buffer: Buffer): { frame: Buffer; remaining: Buffer
     return null;
   }
   const length = slice.readUInt32BE(14);
-  const frameLen = HEADER_SIZE_6699 + length;
+  // `length` excludes the 4-byte suffix; without it the frame is cut short and the
+  // leftover bytes desync every following frame in the stream
+  const frameLen = HEADER_SIZE_6699 + length + 4;
   if (slice.length < frameLen) {
     return null;
   }

--- a/src/local/protocol/ProtocolV35.ts
+++ b/src/local/protocol/ProtocolV35.ts
@@ -21,7 +21,7 @@
 import { Protocol } from './Protocol';
 import {
   hmac, encryptGCM,
-  packMessage6699, packMessage55AA, unpackMessage6699,
+  packMessage6699, unpackMessage6699,
   isFrameComplete, extractFrame,
   NO_VERSION_HEADER_CMDS,
 } from './ProtocolUtilities';
@@ -32,8 +32,15 @@ const VERSION_HEADER_35 = Buffer.from('3.5' + '\x00'.repeat(12), 'latin1');
 export class ProtocolV35 implements Protocol {
   encodeFrame(cmd: number, data: Buffer, seqNo: number, sessionKey?: Buffer, _deviceKey?: Buffer): Buffer {
     if (!sessionKey) {
-      // During key exchange (before session key exists), send as 0x55AA plain
-      return packMessage55AA(seqNo, cmd, data);
+      // v3.5 has no plaintext frames: the key-exchange commands are 0x6699/GCM too,
+      // keyed with the device key until the session key exists.  See TinyTuya
+      // XenonDevice._encode_message, which packs every v3.5 message as 0x6699.
+      // A 0x55AA frame here is dropped by the device without any reply, so the
+      // handshake never completes.
+      if (!_deviceKey) {
+        throw new Error('v3.5 key exchange requires the device key');
+      }
+      return packMessage6699(seqNo, cmd, data, _deviceKey);
     }
 
     let plaintext = data;

--- a/src/shared/accessory/AirConditionerAccessory.ts
+++ b/src/shared/accessory/AirConditionerAccessory.ts
@@ -11,7 +11,7 @@ import { configureTempDisplayUnits } from './characteristic/TemperatureDisplayUn
 
 const SCHEMA_CODE = {
   // AirConditioner
-  ACTIVE: ['switch'],
+  ACTIVE: ['switch', 'switch_1'],
   MODE: ['mode'],
   WORK_STATE: ['work_status', 'mode'],
   CURRENT_TEMP: ['temp_current'],
@@ -206,10 +206,15 @@ export default class AirConditionerAccessory extends BaseAccessory {
     const { INACTIVE, HEATING, COOLING } = this.Characteristic.CurrentHeaterCoolerState;
     this.mainService().getCharacteristic(this.Characteristic.CurrentHeaterCoolerState)
       .onGet(() => {
-        const status = this.getStatus(schema.code)!;
-        if (status.value === 'heating' || status.value === 'hot') {
+        // A schema entry can exist (from config or dpMapping) while the device never
+        // reports that DP; reading `.value` off undefined throws inside the read
+        // handler, and HomeKit then marks the WHOLE accessory "No Response" even
+        // though writes keep working.
+        const status = this.getStatus(schema.code);
+        const workState = status?.value;
+        if (workState === 'heating' || workState === 'hot') {
           return HEATING;
-        } else if (status.value === 'cooling' || status.value === 'cold') {
+        } else if (workState === 'cooling' || workState === 'cold') {
           return COOLING;
         } else {
           return INACTIVE;

--- a/src/shared/accessory/characteristic/RotationSpeed.ts
+++ b/src/shared/accessory/characteristic/RotationSpeed.ts
@@ -42,7 +42,7 @@ function configureRotationSpeedInteger(
 
   const onGetHandler = () => {
     const status = accessory.getStatus(schema.code)!;
-    const value = status.value as number / multiple;
+    const value = (status?.value as number ?? 0) / multiple;
     let level = ((value - hapProperty.minValue!) / hapProperty.minStep!);
     if (hapProperty.minValue !== 0) {
       level += 1;
@@ -89,7 +89,7 @@ function configureRotationSpeedEnum(
 
   const onGetHandler = () => {
     const status = accessory.getStatus(schema.code)!;
-    const index = range.indexOf(status.value as string);
+    const index = range.indexOf(status?.value as string);
     const level = index + 1;
     const hapValue = level * rotationSpeedProperty.minStep!;
     return limit(hapValue, rotationSpeedProperty.minValue!, rotationSpeedProperty.maxValue!);
@@ -169,7 +169,7 @@ function configureRotationSpeedOn(
   service.getCharacteristic(accessory.Characteristic.RotationSpeed)
     .onGet(() => {
       const status = accessory.getStatus(schema.code)!;
-      return (status.value as boolean) ? 100 : 0;
+      return (status?.value as boolean) ? 100 : 0;
     })
     .setProps(props);
 }

--- a/src/shared/accessory/characteristic/TemperatureDisplayUnits.ts
+++ b/src/shared/accessory/characteristic/TemperatureDisplayUnits.ts
@@ -11,11 +11,18 @@ export function configureTempDisplayUnits(accessory: BaseAccessory, service: Ser
   service.getCharacteristic(accessory.Characteristic.TemperatureDisplayUnits)
     .onGet(() => {
       const status = accessory.getStatus(schema.code)!;
-      return ((status.value as string).toLowerCase() === 'c') ? CELSIUS : FAHRENHEIT;
+      // Fall back to Celsius when the device never reports the unit DP, rather than
+      // throwing and taking the whole accessory offline.
+      const unitValue = status?.value;
+      if (typeof unitValue !== 'string') {
+        return CELSIUS;
+      }
+      return (unitValue.toLowerCase() === 'c') ? CELSIUS : FAHRENHEIT;
     })
     .onSet(async value => {
       const status = accessory.getStatus(schema.code)!;
-      const isLowerCase = (status.value as string).toLowerCase() === status.value;
+      const current = typeof status?.value === 'string' ? status.value : 'c';
+      const isLowerCase = current.toLowerCase() === current;
 
       let unit = (value === CELSIUS) ? 'c' : 'f';
       unit = isLowerCase ? unit.toLowerCase() : unit.toUpperCase();

--- a/test/airConditioner.test.ts
+++ b/test/airConditioner.test.ts
@@ -275,7 +275,7 @@ describe('AirConditionerAccessory', () => {
 
     test('should include switch, mode, work_status, and temp_current', () => {
       const required = airConditionerAccessory.requiredSchema();
-      expect(required).toContainEqual(['switch']);
+      expect(required).toContainEqual(['switch', 'switch_1']);
       expect(required).toContainEqual(['mode']);
     });
   });

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -53,6 +53,9 @@ describe('ProtocolFactory', () => {
 
 describe('Protocol Base Interface', () => {
   let protocol: ReturnType<typeof ProtocolFactory.createProtocol>;
+  // v3.5 encrypts every frame, so encoding always needs a key: the session key once
+  // the handshake is done, the device key before that.
+  const deviceKey = Buffer.from('0123456789abcdef');
 
   beforeEach(() => {
     protocol = ProtocolFactory.createProtocol('3.5');
@@ -64,7 +67,7 @@ describe('Protocol Base Interface', () => {
       const data = Buffer.from([0xaa, 0xbb, 0xcc]);
       const seqNo = 1;
 
-      const frame = protocol.encodeFrame(cmd, data, seqNo);
+      const frame = protocol.encodeFrame(cmd, data, seqNo, undefined, deviceKey);
 
       expect(frame).toBeInstanceOf(Buffer);
       expect(frame.length).toBeGreaterThan(0);
@@ -87,7 +90,7 @@ describe('Protocol Base Interface', () => {
       const data = Buffer.alloc(0);
       const seqNo = 1;
 
-      const frame = protocol.encodeFrame(cmd, data, seqNo);
+      const frame = protocol.encodeFrame(cmd, data, seqNo, undefined, deviceKey);
 
       expect(frame).toBeInstanceOf(Buffer);
       expect(frame.length).toBeGreaterThan(0);
@@ -101,7 +104,7 @@ describe('Protocol Base Interface', () => {
       const data = Buffer.from([0xaa, 0xbb]);
       const seqNo = 1;
 
-      const frame = protocol.encodeFrame(cmd, data, seqNo);
+      const frame = protocol.encodeFrame(cmd, data, seqNo, undefined, deviceKey);
       const isComplete = protocol.isFrameComplete(frame);
 
       expect(typeof isComplete).toBe('boolean');
@@ -129,7 +132,7 @@ describe('Protocol Base Interface', () => {
       const data = Buffer.from([0xaa, 0xbb]);
       const seqNo = 1;
 
-      const encodedFrame = protocol.encodeFrame(cmd, data, seqNo);
+      const encodedFrame = protocol.encodeFrame(cmd, data, seqNo, undefined, deviceKey);
       const result = protocol.extractFrame(encodedFrame);
 
       if (result) {
@@ -249,12 +252,13 @@ describe('packMessage6699 / unpackMessage6699 round-trips', () => {
   test('GCM frame round-trip preserves seqno, cmd, and payload', () => {
     const plaintext = Buffer.from('{"dps":{"1":true}}');
     const frame = packMessage6699(42, 13, plaintext, key);
-    const msg = unpackMessage6699(frame, key);
+    // This is a client→device frame, which carries no retcode, so unpack must be
+    // told not to strip one.  Frames coming from a device always carry it.
+    const msg = unpackMessage6699(frame, key, true);
     expect(msg).not.toBeNull();
     expect(msg!.seqno).toBe(42);
     expect(msg!.cmd).toBe(13);
     expect(msg!.hmacOk).toBe(true);
-    // Payload starts with '{' (not 0x00 0x00), so retcode stripping does not apply
     expect(msg!.payload).toEqual(plaintext);
   });
 
@@ -270,18 +274,29 @@ describe('packMessage6699 / unpackMessage6699 round-trips', () => {
     const frame = packMessage6699(1, 16, plaintext, key);
     // header=18, iv=12, ciphertext=37, tag=16, suffix=4 → total 87 bytes
     expect(frame.length).toBe(18 + 12 + 37 + 16 + 4);
-    // length field at offset 14 should be 12+37+16+4 = 69
-    expect(frame.readUInt32BE(14)).toBe(12 + 37 + 16 + 4);
+    // length field at offset 14 should be 12+37+16 = 65: it covers IV + ciphertext +
+    // tag and NOT the suffix (TinyTuya message_helper.pack_message)
+    expect(frame.readUInt32BE(14)).toBe(12 + 37 + 16);
   });
 });
 
 describe('ProtocolV35 encode + decode round-trips', () => {
   const key = Buffer.from('0123456789abcdef');
   const proto = new ProtocolV35();
+  // Frames sent by a device carry a 4-byte retcode ahead of the payload, which
+  // decodeFrame strips.  Prepend one when building a frame that stands in for a
+  // device reply, otherwise the first four payload bytes are lost.
+  const RETCODE = Buffer.alloc(4);
+  const asDeviceFrame = (cmd: number, payload: Buffer, seq = 1, versionHeader = false): Buffer => {
+    const body = versionHeader
+      ? Buffer.concat([Buffer.from('3.5' + '\x00'.repeat(12), 'latin1'), payload])
+      : payload;
+    return packMessage6699(seq, cmd, Buffer.concat([RETCODE, body]), key);
+  };
 
   test('data command (cmd 13) with session key: round-trip strips version header', () => {
     const payload = Buffer.from('{"protocol":5,"t":1234,"data":{"dps":{"1":true}}}');
-    const frame = proto.encodeFrame(13, payload, 1, key);
+    const frame = asDeviceFrame(13, payload, 1, true);
     const decoded = proto.decodeFrame(frame, key, key);
     expect(decoded).not.toBeNull();
     expect(decoded!.cmd).toBe(13);
@@ -290,7 +305,7 @@ describe('ProtocolV35 encode + decode round-trips', () => {
 
   test('key exchange cmd 3 (NO_VERSION_HEADER_CMDS): no version header added or stripped', () => {
     const nonce = Buffer.from('0123456789abcdef'); // 16 bytes
-    const frame = proto.encodeFrame(3, nonce, 1, key);
+    const frame = asDeviceFrame(3, nonce);
     const decoded = proto.decodeFrame(frame, key, key);
     expect(decoded).not.toBeNull();
     expect(decoded!.cmd).toBe(3);
@@ -299,8 +314,8 @@ describe('ProtocolV35 encode + decode round-trips', () => {
 
   test('decodeFrame falls back to deviceKey when sessionKey is absent (pre-exchange)', () => {
     const nonce = Buffer.from('0123456789abcdef');
-    // Encode with key (simulating device using deviceKey before exchange)
-    const frame = proto.encodeFrame(3, nonce, 1, key);
+    // Simulates the device replying with the device key, before a session exists
+    const frame = asDeviceFrame(3, nonce, 1);
     // Decode without passing sessionKey - should use deviceKey as fallback
     const decoded = proto.decodeFrame(frame, key); // sessionKey omitted
     expect(decoded).not.toBeNull();

--- a/test/protocol35Frames.test.ts
+++ b/test/protocol35Frames.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from '@jest/globals';
+
+/**
+ * Wire-format tests for the v3.5 (0x6699) frame layout.
+ *
+ * The golden vectors below were produced by TinyTuya (message_helper.pack_message
+ * with prefix 0x6699), the reference implementation these frames follow.  They are
+ * reproducible with:
+ *
+ *   from tinytuya.core import header as H
+ *   from tinytuya.core.message_helper import TuyaMessage, pack_message
+ *   msg = TuyaMessage(seq, cmd, None, payload, 0, True, H.PREFIX_6699_VALUE, b'0123456789ab')
+ *   pack_message(msg, hmac_key=key).hex()
+ *
+ * The IV is pinned to '0123456789ab' so the bytes are deterministic.  At runtime the
+ * IV is random; it travels inside the frame, so any unique value is wire-compatible.
+ */
+
+// Pin the 12-byte GCM nonce only while `pinnedIv` is set, so the golden vectors can
+// be compared byte for byte while every other use of randomBytes stays real.
+let pinnedIv: Buffer | null = null;
+
+jest.mock('crypto', () => {
+  const actual = jest.requireActual<typeof import('crypto')>('crypto');
+  return {
+    ...actual,
+    randomBytes: (size: number): Buffer =>
+      (size === 12 && pinnedIv ? Buffer.from(pinnedIv) : actual.randomBytes(size)),
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const {
+  packMessage6699,
+  unpackMessage6699,
+  isFrameComplete,
+  extractFrame,
+  HEADER_SIZE_6699,
+  PREFIX_6699,
+  SUFFIX_6699,
+} = require('../src/local/protocol/ProtocolUtilities');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { ProtocolV35 } = require('../src/local/protocol/ProtocolV35');
+
+const DEVICE_KEY = Buffer.from('0123456789abcdef', 'latin1');
+const SESSION_KEY = Buffer.from('00112233445566778899aabbccddeeff', 'hex');
+const FIXED_IV = Buffer.from('0123456789ab', 'latin1');
+const NONCE = Buffer.from('aabbccddeeff00112233445566778899', 'hex');
+
+const GOLDEN = {
+  keyExchangeStart:
+    '00006699000000000001000000030000002c303132333435363738396162c8f9c126c09f2d98213033b1'
+    + 'e2ad2b6a4ea62b6ce07e9a059e670d5dca806da600009966',
+  dpQueryNew:
+    '00006699000000000003000000100000003a303132333435363738396162790702f77ca154ac87f222ad'
+    + 'ba96e03e078b5fa743be4093905c8d4673cd0055f1c00304a7f59f502fb819f58afa00009966',
+  heartbeat:
+    '00006699000000000005000000090000001c3031323334353637383961628f7981ee45e7bc696425ac42'
+    + '39b34ee000009966',
+};
+
+function withFixedIv<T>(fn: () => T): T {
+  pinnedIv = FIXED_IV;
+  try {
+    return fn();
+  } finally {
+    pinnedIv = null;
+  }
+}
+
+describe('v3.5 0x6699 frame format', () => {
+  describe('length field', () => {
+    test('counts IV + ciphertext + tag, excluding the 4-byte suffix', () => {
+      const plaintext = Buffer.from('{"dps":{"1":true}}');
+      const frame = packMessage6699(1, 13, plaintext, SESSION_KEY);
+
+      const declared = frame.readUInt32BE(14);
+      expect(declared).toBe(12 + plaintext.length + 16);
+      // whole frame = header + declared length + suffix
+      expect(frame.length).toBe(HEADER_SIZE_6699 + declared + 4);
+      expect(frame.readUInt32BE(0)).toBe(PREFIX_6699);
+      expect(frame.readUInt32BE(frame.length - 4)).toBe(SUFFIX_6699);
+    });
+
+    test('round-trips through unpackMessage6699', () => {
+      // A device→client frame carries a 4-byte retcode ahead of the payload.
+      const body = Buffer.from('{"dps":{"1":true,"2":250}}');
+      const withRetcode = Buffer.concat([Buffer.alloc(4), body]);
+      const frame = packMessage6699(7, 16, withRetcode, SESSION_KEY);
+
+      const msg = unpackMessage6699(frame, SESSION_KEY);
+      expect(msg).not.toBeNull();
+      expect(msg.seqno).toBe(7);
+      expect(msg.cmd).toBe(16);
+      expect(msg.hmacOk).toBe(true);
+      expect(msg.payload.toString()).toBe(body.toString());
+    });
+
+    test('returns null when the frame is truncated', () => {
+      const frame = packMessage6699(1, 9, Buffer.alloc(4), SESSION_KEY);
+      expect(unpackMessage6699(frame.subarray(0, frame.length - 1), SESSION_KEY)).toBeNull();
+    });
+
+    test('returns null when the auth tag does not verify', () => {
+      const frame = packMessage6699(1, 16, Buffer.alloc(8), SESSION_KEY);
+      const tampered = Buffer.from(frame);
+      tampered[HEADER_SIZE_6699 + 12] ^= 0xff; // flip a ciphertext bit
+      expect(unpackMessage6699(tampered, SESSION_KEY)).toBeNull();
+    });
+  });
+
+  describe('frame boundaries', () => {
+    test('isFrameComplete requires the suffix as well', () => {
+      const frame = packMessage6699(1, 16, Buffer.alloc(16), SESSION_KEY);
+      expect(isFrameComplete(frame)).toBe(true);
+      expect(isFrameComplete(frame.subarray(0, frame.length - 1))).toBe(false);
+    });
+
+    test('extractFrame consumes the whole frame, leaving nothing behind', () => {
+      const frame = packMessage6699(2, 16, Buffer.alloc(16), SESSION_KEY);
+      const extracted = extractFrame(frame);
+
+      expect(extracted).not.toBeNull();
+      expect(extracted.frame.length).toBe(frame.length);
+      // A short read here leaves suffix bytes in the buffer and desyncs every
+      // following frame in the stream.
+      expect(extracted.remaining.length).toBe(0);
+    });
+
+    test('extractFrame splits two concatenated frames cleanly', () => {
+      const first = packMessage6699(1, 16, Buffer.alloc(8), SESSION_KEY);
+      const second = packMessage6699(2, 9, Buffer.alloc(4), SESSION_KEY);
+      const stream = Buffer.concat([first, second]);
+
+      const a = extractFrame(stream);
+      expect(a.frame).toEqual(first);
+      const b = extractFrame(a.remaining);
+      expect(b.frame).toEqual(second);
+      expect(b.remaining.length).toBe(0);
+    });
+  });
+
+  describe('GCM nonce', () => {
+    test('differs between two frames with identical content', () => {
+      const plaintext = Buffer.from('same');
+      const a = packMessage6699(1, 16, plaintext, SESSION_KEY);
+      const b = packMessage6699(1, 16, plaintext, SESSION_KEY);
+
+      const ivA = a.subarray(HEADER_SIZE_6699, HEADER_SIZE_6699 + 12);
+      const ivB = b.subarray(HEADER_SIZE_6699, HEADER_SIZE_6699 + 12);
+      expect(ivA.equals(ivB)).toBe(false);
+    });
+  });
+
+  describe('matches TinyTuya byte for byte', () => {
+    test('SESS_KEY_NEG_START (cmd 3) keyed with the device key', () => {
+      const frame = withFixedIv(() => new ProtocolV35().encodeFrame(3, NONCE, 1, undefined, DEVICE_KEY));
+      expect(frame.toString('hex')).toBe(GOLDEN.keyExchangeStart);
+    });
+
+    test('DP_QUERY_NEW (cmd 16) keyed with the session key', () => {
+      const payload = Buffer.from('{"gwId":"test","devId":"test"}');
+      const frame = withFixedIv(() => new ProtocolV35().encodeFrame(16, payload, 3, SESSION_KEY, DEVICE_KEY));
+      expect(frame.toString('hex')).toBe(GOLDEN.dpQueryNew);
+    });
+
+    test('HEART_BEAT (cmd 9)', () => {
+      const frame = withFixedIv(() => new ProtocolV35().encodeFrame(9, Buffer.alloc(0), 5, SESSION_KEY, DEVICE_KEY));
+      expect(frame.toString('hex')).toBe(GOLDEN.heartbeat);
+    });
+
+    test('decodes a TinyTuya-produced frame', () => {
+      // The other direction: a frame generated by TinyTuya must be readable here,
+      // including the length field that excludes the suffix.
+      const frame = Buffer.from(GOLDEN.dpQueryNew, 'hex');
+      expect(isFrameComplete(frame)).toBe(true);
+
+      const msg = unpackMessage6699(frame, SESSION_KEY);
+      expect(msg).not.toBeNull();
+      expect(msg.cmd).toBe(16);
+      expect(msg.hmacOk).toBe(true);
+    });
+  });
+
+  describe('key exchange', () => {
+    test('uses the 0x6699 format before a session key exists', () => {
+      const frame = new ProtocolV35().encodeFrame(3, NONCE, 1, undefined, DEVICE_KEY);
+      // A 0x55AA frame here is dropped by the device without any reply.
+      expect(frame.readUInt32BE(0)).toBe(PREFIX_6699);
+      expect(unpackMessage6699(frame, DEVICE_KEY)).not.toBeNull();
+    });
+
+    test('throws when no device key is available', () => {
+      expect(() => new ProtocolV35().encodeFrame(3, NONCE, 1, undefined, undefined)).toThrow();
+    });
+
+    test('does not prepend the version header to key-exchange commands', () => {
+      const frame = new ProtocolV35().encodeFrame(3, NONCE, 1, undefined, DEVICE_KEY);
+      const msg = unpackMessage6699(frame, DEVICE_KEY);
+      // unpack strips the 4-byte retcode, so compare against the nonce minus those bytes
+      expect(msg.payload).toEqual(NONCE.subarray(4));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Protocol 3.5 local mode could not work at all: the device never answered the session-key handshake, so the accessory stayed at **"Not Responding"** in HomeKit even with a correct local key, correct IP and `protocolVersion: "3.5"` in config.

The root cause is a 4-byte off-by-one in the `0x6699` frame layout, plus the key-exchange commands being sent unencrypted. On top of that, four gaps in the connection lifecycle let a session hang or go stale silently, and a few characteristic read handlers could take a whole accessory offline.

Everything here was verified against **TinyTuya**, which talks to the same device successfully, and then on real hardware: a Daikin air conditioner with a **WiFiKit-II-DK** module (`category: kt`, protocol 3.5) running against Homebridge 2.2.1 / Node 24 on a Synology DS223J.

Verified before → after on that device:

| | before | after |
|---|---|---|
| Reply to the key exchange | none, ever | ~9 ms |
| DPs read | 0 | 21 |
| Session stability | never established | 28 h, no dropped heartbeat |
| HomeKit tile | "Not Responding" | normal, values correct |
| Change made on the physical remote | never noticed | picked up within one poll |

---

## 1. Wire format: the `0x6699` length field

`packMessage6699` counted the 4-byte suffix in the header's length field. TinyTuya does not:

```python
# tinytuya/core/message_helper.py — pack_message()
msg_len = len(msg.payload) + (struct.calcsize(H.MESSAGE_END_FMT_6699) - 4) + 12
#                             '>16sI' = 20, minus the 4-byte suffix → tag(16)     + IV(12)
```

So the field covers **IV(12) + ciphertext + tag(16)** and stops there. Declaring 4 bytes too many makes the device drop the frame **without any reply**, which is exactly the observed symptom — a handshake that goes out and never comes back.

The same field was then read back *without* the suffix in three places (`unpackMessage6699`, `isFrameComplete`, `extractFrame`), so replies were cut 4 bytes short and the leftover suffix bytes desynced every following frame in the stream. The two errors were self-consistent inside the plugin, which is why nothing looked wrong locally.

```diff
-  const length = 12 + plaintext.length + 16 + 4; // IV(12) + cipher(N) + tag(16) + suffix(4)
+  const length = 12 + plaintext.length + 16;
```
```diff
-  const totalLen = HEADER_SIZE_6699 + length;
+  const totalLen = HEADER_SIZE_6699 + length + 4;
```

## 2. v3.5 has no plaintext frames

`encodeFrame` fell back to a plain `0x55AA` frame while no session key existed — i.e. for the key exchange itself:

```ts
if (!sessionKey) {
  // During key exchange (before session key exists), send as 0x55AA plain
  return packMessage55AA(seqNo, cmd, data);
}
```

TinyTuya packs **every** v3.5 message as `0x6699`, keyed with the device key until the session key is derived (`XenonDevice._encode_message`: `if self.version >= 3.5: msg = TuyaMessage(..., H.PREFIX_6699_VALUE, True)`). A `0x55AA` frame is discarded by the device, so the handshake never starts.

Since there is no valid v3.5 frame to produce without a key, `encodeFrame` now throws when neither key is available, instead of emitting bytes the device will ignore.

## 3. GCM nonce and retcode handling

- The nonce was derived from `Date.now() / 100`, so it repeats for every message sent inside the same 100 ms window — nonce reuse under one key, which GCM does not tolerate. Now 12 random bytes, matching TinyTuya's `os.urandom(12)`. The nonce travels inside the frame, so this is wire-compatible either way.
- The 4-byte retcode was stripped by sniffing for two leading zero bytes. Device→client frames always carry it, so it is now stripped unconditionally, with a `noRetcode` option mirroring the one `unpackMessage55AA` already has for frames produced on this side. The old heuristic mis-sliced binary payloads: a key-exchange reply starts with a random nonce, so it was only stripped about 1 time in 65536.

## 4. Connection lifecycle

Four issues that each let a connection fail quietly. None is specific to this device, but this device surfaced all of them.

**No watchdog on the key exchange.** `connTimeout` is cleared as soon as TCP connects, and the heartbeat and poll timers only start once a session key exists. A device that accepts the connection but never answers `cmd 3` therefore left the socket `ESTABLISHED` and unusable **indefinitely** — measured at 10 hours here, with every command timing out and not one log line explaining why. There is now a `handshakeTimeout` (15 s) that drops the socket so the existing close/reconnect path dials again.

**A clean close had no reconnect path.** `sock.on('close')` only cleared state, so a device that hung up — or a socket dropped deliberately, as above — stayed offline until the next rediscovery sweep. It now schedules a reconnect using the same backoff as the error path.

**The heartbeat was unforgiving.** One ping every 9 s, socket dropped if no reply within a hardcoded 5 s. On a small host (1 GB NAS) the event loop stalls under load and replies arrive 15–40 s late; a ping scheduled every 9 s was observed going out 2.5 minutes apart. Every dropped socket lingers on the WiFi module until it runs out of its few connection slots, after which it stops answering **anyone** — TinyTuya included, which is how a plugin-side bug ends up looking like broken hardware. Now 25 s between pings, 20 s to answer, 2 misses tolerated.

**State was queried once per connection.** The plugin then relied on the device pushing changes. This module never pushes, so the values captured at connect time stayed frozen for the life of the connection. Measured: the device reported 28.5 °C while HomeKit still showed the 30.5 °C read **28 hours** earlier; on/off and mode were equally stale, so operating the unit with its remote was invisible to HomeKit. `_schedulePoll` now re-queries every 60 s. Devices that do push updates simply answer with the same values, so nothing changes for them.

## 5. Read handlers taking accessories offline

A schema entry can exist while the device never reports that DP. Reading `.value` off the resulting `undefined` threw inside the read handler, and HomeKit marks the **whole** accessory "No Response" when a read throws — while writes on the same accessory keep working. That mismatch is genuinely confusing to diagnose: the air conditioner responded to on/off from the Home app while its tile showed no values at all.

Guarded `CurrentHeaterCoolerState`, all three `RotationSpeed` variants, and `TemperatureDisplayUnits` (falling back to Celsius).

Concretely on this model: `temp_unit_convert` maps to dp 104, which the device does not have, and `work_status` maps to dp 4 — the same DP as `mode`, so only one of the two survives into the status list. Either was enough to take the accessory offline.

Also accepting `switch_1` alongside `switch` as the AC power DP; some models report the numbered form and previously failed the required-schema check with `Missing one of the required schema: ['switch']`.

---

## New config options

All optional, all defaulted to the values above; existing configs behave the same except for the fixed defaults (`pingGap` 9 → 25).

| key | default | meaning |
|---|---|---|
| `pingGap` | 25 | seconds between heartbeats |
| `pingTimeout` | 20 | seconds to wait for a heartbeat reply |
| `pingRetries` | 2 | missed heartbeats tolerated before dropping the socket |
| `pollGap` | 60 | seconds between state refreshes; `0` disables |
| `handshakeTimeout` | 15 | seconds to wait for the v3.4/v3.5 key-exchange reply |

I did not add these to `config.schema.json` — happy to, if you'd like them exposed in the UI.

## Testing

- `npm test` — **973 passed**, up from 958 on `beta-3.0.0`, with the same 2 pre-existing suite failures (`home.test.ts`, `custom.test.ts` need `~/.homebridge-dev/config.json`, unrelated to this change).
- `npm run lint` — clean.
- `npm run build` — clean.
- `test/protocol35Frames.test.ts` (new, 15 cases): length field, frame boundaries incl. two concatenated frames, nonce uniqueness, key-exchange format, and **golden vectors produced by TinyTuya** with a pinned IV, compared byte for byte in both directions. The reproduction snippet is in the file header, so the vectors can be regenerated independently.
- Against a TinyTuya-backed fake device (a Python peer that builds frames with TinyTuya's own packer): full handshake → status read → control round-trip. A variant that accepts TCP and deliberately ignores `cmd 3` exercises the new handshake watchdog.
- On the real device: 25 patched-plugin edits deployed to a running container, then handshake, 21 DPs, 28 h of uninterrupted heartbeats, correct HomeKit ranges (16–30 °C, step 0.5), and an externally-made setpoint change picked up within one poll interval.

### Tests I had to change

Four existing cases in `test/protocol.test.ts` and one in `test/airConditioner.test.ts` asserted the pre-fix behaviour:

- `encodeFrame` for v3.5 is now called with a key (previously it silently produced a `0x55AA` frame with none).
- The length-field assertion now expects `12 + N + 16` rather than `12 + N + 16 + 4`.
- Round-trip cases that feed a self-encoded frame back through `decodeFrame` now prepend a retcode, since that is what a device sends; a helper `asDeviceFrame()` makes the direction explicit.
- `requiredSchema` now contains `['switch', 'switch_1']`.

## Notes

- No change to v3.1–v3.4 paths: the `0x55AA` packer/unpacker is untouched, and the frame-boundary fixes are inside the `0x6699` branches.
- Everything is on `beta-3.0.0`. Happy to rebase, split this into separate PRs (the frame-format fix stands alone and is the one that makes 3.5 work at all), or add the config-schema entries — just say which you prefer.
- The three commits are scoped to frame format / connection lifecycle / accessory handlers if that helps reviewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
