### PR TITLE
fix(WindowCovering): actively push STOPPED state when physical limits…

### DIFF
--- a/src/accessory/WindowCoveringAccessory.ts
+++ b/src/accessory/WindowCoveringAccessory.ts
@@ -72,6 +72,14 @@ export default class WindowCoveringAccessory extends BaseAccessory {
 
         this.log.warn('Unknown CurrentPosition:', status.value);
         return 50;
+      })
+      .on('change', (context) => {
+        if (context.newValue === 0 || context.newValue === 100) {
+          service.updateCharacteristic(
+            this.Characteristic.PositionState, 
+            this.Characteristic.PositionState.STOPPED
+          );
+        }
       });
   }
 
@@ -87,25 +95,22 @@ export default class WindowCoveringAccessory extends BaseAccessory {
     service.getCharacteristic(this.Characteristic.PositionState)
       .onGet(() => {
         if (!currentSchema || !targetSchema) {
-          return STOPPED; // (A)
+          return STOPPED;
         }
 
         const currentStatus = this.getStatus(currentSchema.code)!;
         const targetStatus = this.getStatus(targetSchema.code)!;
 
-        // Fix applied: Override for physical RF remote bounds check.
-        // If current position reaches hardware limits, force STOPPED state
-        // to prevent UI freezing due to desynced targetStatus.
         if (currentStatus.value === 0 || currentStatus.value === 100) {
           return STOPPED;
         }
 
-        if (targetStatus.value === 100 && currentStatus.value !== 100) { // (B)
+        if (targetStatus.value === 100 && currentStatus.value !== 100) {
           return INCREASING;
-        } else if (targetStatus.value === 0 && currentStatus.value !== 0) { // (C)
+        } else if (targetStatus.value === 0 && currentStatus.value !== 0) {
           return DECREASING;
         } else {
-          return STOPPED; // (D)
+          return STOPPED;
         }
       });
   }

--- a/src/accessory/WindowCoveringAccessory.ts
+++ b/src/accessory/WindowCoveringAccessory.ts
@@ -76,8 +76,8 @@ export default class WindowCoveringAccessory extends BaseAccessory {
       .on('change', (context) => {
         if (context.newValue === 0 || context.newValue === 100) {
           service.updateCharacteristic(
-            this.Characteristic.PositionState, 
-            this.Characteristic.PositionState.STOPPED
+            this.Characteristic.PositionState,
+            this.Characteristic.PositionState.STOPPED,
           );
         }
       });


### PR DESCRIPTION
… are reached

### ♻️ Current situation
In a previous PR (#45), we added a bounds check to `configurePositionState`'s `onGet` method to fix an issue where Tuya Zigbee tubular blinds using an RF remote would get stuck in an "Opening/Closing" state. 

While that fix works perfectly when the Apple Home app performs a "pull" (e.g., when reopening the app), I discovered that it is insufficient if the app is already open and actively observing the accessory. Because the motor updates its `CurrentPosition` but delays its `PositionState`, the UI stays stuck waiting for a "push" update that the movement has stopped.

### 💡 Proposed solution
To make the fix robust, I've added an event listener to the `CurrentPosition` characteristic using `.on('change', ...)`. 

Now, when the `CurrentPosition` actively updates to `0` or `100` via a push event from the Tuya cloud, the plugin will proactively fire an `updateCharacteristic` to also push the `STOPPED` state to the Apple HomeKit bus. This instantly terminates the Opening/Closing animation in the app while the user is watching it, keeping the UI perfectly synced.

My apologies for missing this nuance in the original PR! This active push combined with the previous passive `onGet` fix provides a complete resolution for these stubborn Zigbee motors.

### ⚙️ Release Notes
* **Bug Fixes**
  * `WindowCovering`: Fixed an edge case where the accessory would remain stuck in the "Opening" or "Closing" state if the Apple Home app was actively open during a physical RF remote operation.

### ➕ Additional Information
N/A

### Testing
Tested locally with a Tuya Zigbee tubular blind. With the Home app open, triggering the physical RF remote now immediately resolves the tile status to "Open" or "Closed" as soon as the motor hits the `0%` or `100%` mark, eliminating the perpetual loading animation.

## :recycle: Current situation

_Describe the current situation. Explain current problems, if there are any. Be as descriptive as possible (e.g., including examples or code snippets)._

## :bulb: Proposed solution

_Describe the proposed solution and changes. How does it affect the project? How does it affect the internal structure (e.g., refactorings)?_

## :gear: Release Notes

_Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features._

## :heavy_plus_sign: Additional Information

_If applicable, provide additional context in this section._

### Testing

_Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?_

### Reviewer Nudging

_Where should the reviewer start? what is a good entry point?_
