### PR TITLE
fix(accessory): make an air conditioner's swing and fan speed reachable from the Home app

### DIFF
--- a/src/shared/accessory/AirConditionerAccessory.ts
+++ b/src/shared/accessory/AirConditionerAccessory.ts
@@ -6,7 +6,7 @@ import { configureCurrentTemperature } from './characteristic/CurrentTemperature
 import { configureLockPhysicalControls } from './characteristic/LockPhysicalControls';
 import { configureRelativeHumidityDehumidifierThreshold } from './characteristic/RelativeHumidityDehumidifierThreshold';
 import { configureRotationSpeedLevel } from './characteristic/RotationSpeed';
-// import { configureSwingMode } from './characteristic/SwingMode';
+import { configureSwingMode } from './characteristic/SwingMode';
 import { configureTempDisplayUnits } from './characteristic/TemperatureDisplayUnits';
 
 const SCHEMA_CODE = {
@@ -19,7 +19,14 @@ const SCHEMA_CODE = {
   SPEED_LEVEL: ['fan_speed_enum', 'windspeed'],
   LOCK: ['lock', 'child_lock'],
   TEMP_UNIT_CONVERT: ['temp_unit_convert', 'c_f'],
-  SWING: ['switch_horizontal', 'switch_vertical'],
+  // Vertical first: it is the axis most units expose and the one users reach for.
+  // HeaterCooler carries a single SwingMode characteristic, so the remaining axes are
+  // published as switches (see configureSwingSwitches).
+  SWING: ['switch_vertical', 'switch_horizontal'],
+  SWING_AXES: [
+    { code: 'switch_vertical', name: 'Vertical Swing' },
+    { code: 'switch_horizontal', name: 'Horizontal Swing' },
+  ],
   // Dehumidifier
   CURRENT_HUMIDITY: ['humidity_current'],
   TARGET_HUMIDITY: ['humidity_set'],
@@ -44,6 +51,8 @@ export default class AirConditionerAccessory extends BaseAccessory {
     this.configureAirConditioner();
     this.configureDehumidifier();
     this.configureFan();
+    this.configureSwingSwitches();
+    this.configureFanSpeedTile();
 
     // Add extra sensors for home automation use.
     configureCurrentTemperature(this, undefined, this.getSchema(...SCHEMA_CODE.CURRENT_TEMP));
@@ -91,7 +100,7 @@ export default class AirConditionerAccessory extends BaseAccessory {
     // Optional Characteristics
     configureLockPhysicalControls(this, service, this.getSchema(...SCHEMA_CODE.LOCK));
     configureRotationSpeedLevel(this, service, this.getSchema(...SCHEMA_CODE.SPEED_LEVEL), ['auto']);
-    // configureSwingMode(this, service, this.getSchema(...SCHEMA_CODE.SWING));
+    configureSwingMode(this, service, this.getSchema(...SCHEMA_CODE.SWING));
     this.configureCoolingThreshouldTemp();
     this.configureHeatingThreshouldTemp();
     configureTempDisplayUnits(this, service, this.getSchema(...SCHEMA_CODE.TEMP_UNIT_CONVERT));
@@ -103,6 +112,12 @@ export default class AirConditionerAccessory extends BaseAccessory {
     const property = modeSchema.property as TuyaDeviceSchemaEnumProperty;
     const dehumidifierCode = property.range.find(code => DEHUMIDIFIER_MODE.includes(code.toLowerCase()));
     if (!dehumidifierCode) {
+      // Subtype-less only, for the same reason as the Fanv2 cleanup below.
+      const staleDehumidifier = this.accessory.services
+        .find(s => s.UUID === this.Service.HumidifierDehumidifier.UUID && !s.subtype);
+      if (staleDehumidifier) {
+        this.accessory.removeService(staleDehumidifier);
+      }
       return;
     }
 
@@ -153,6 +168,15 @@ export default class AirConditionerAccessory extends BaseAccessory {
     const property = modeSchema.property as TuyaDeviceSchemaEnumProperty;
     const fanCode = property.range.find(code => FAN_MODE.includes(code.toLowerCase()));
     if (!fanCode) {
+      // Drop a Fanv2 created by an earlier run: it would keep showing a slider bound
+      // to the same fan-speed DP as the air conditioner, and its Active handler sends
+      // a mode change, so moving that slider switches the unit into fan mode.
+      // Match only the subtype-less service this method creates — getService() ignores
+      // subtypes and would otherwise match the fan-speed tile added below.
+      const staleFan = this.accessory.services.find(s => s.UUID === this.Service.Fanv2.UUID && !s.subtype);
+      if (staleFan) {
+        this.accessory.removeService(staleFan);
+      }
       return;
     }
 
@@ -180,6 +204,88 @@ export default class AirConditionerAccessory extends BaseAccessory {
     configureLockPhysicalControls(this, service, this.getSchema(...SCHEMA_CODE.LOCK));
     configureRotationSpeedLevel(this, service, this.getSchema(...SCHEMA_CODE.SPEED_LEVEL), ['auto']);
     // configureSwingMode(this, service, this.getSchema(...SCHEMA_CODE.SWING));
+  }
+
+  /**
+   * Publish each swing axis the device reports as its own Switch.
+   *
+   * SwingMode is set on the HeaterCooler service as well, but the Home app does not
+   * render that characteristic for a heater-cooler, so without these switches the
+   * louvres cannot be controlled from the Home app at all — on the unit this was
+   * developed against, vertical swing was running (DP reported `true`) with no
+   * control for it anywhere in the app.  Switches are rendered, and other clients
+   * (Eve, Controller for HomeKit) keep using SwingMode.
+   *
+   * A switch is removed again if the device stops reporting that axis.
+   */
+  configureSwingSwitches(): void {
+    for (const axis of SCHEMA_CODE.SWING_AXES) {
+      const schema = this.getSchema(axis.code);
+      const subtype = `swing-${axis.code}`;
+      const existing = this.accessory.getServiceById(this.Service.Switch, subtype);
+
+      if (!schema) {
+        if (existing) {
+          this.accessory.removeService(existing);
+        }
+        continue;
+      }
+
+      const service = existing
+        || this.accessory.addService(this.Service.Switch, axis.name, subtype);
+      // Without ConfiguredName the Home app labels every extra tile with the accessory
+      // name, leaving two identical switches with no way to tell them apart.
+      service.setCharacteristic(this.Characteristic.ConfiguredName, axis.name);
+
+      service.getCharacteristic(this.Characteristic.On)
+        .onGet(() => this.getStatus(schema.code)?.value === true)
+        .onSet(async value => {
+          await this.sendCommands([{ code: schema.code, value: value === true }], true);
+        });
+    }
+  }
+
+  /**
+   * Publish the blower speed as a fan tile when the device has no fan mode.
+   *
+   * RotationSpeed is set on the HeaterCooler service, but the Home app does not
+   * render it there either, so on a unit without a fan mode the speed cannot be
+   * changed from the Home app.  Devices that do have a fan mode already get a Fanv2
+   * from configureFan(), so nothing is added for them.
+   *
+   * Active mirrors the power DP: this fan IS the air conditioner's blower, so unlike
+   * configureFan() it must never send a mode change.
+   */
+  configureFanSpeedTile(): void {
+    const modeSchema = this.getSchema(...SCHEMA_CODE.MODE);
+    const modeProperty = modeSchema?.property as TuyaDeviceSchemaEnumProperty | undefined;
+    const hasFanMode = modeProperty?.range.some(code => FAN_MODE.includes(code.toLowerCase()));
+
+    const speedSchema = this.getSchema(...SCHEMA_CODE.SPEED_LEVEL);
+    const activeSchema = this.getSchema(...SCHEMA_CODE.ACTIVE);
+
+    const subtype = 'fan-speed';
+    const existing = this.accessory.getServiceById(this.Service.Fanv2, subtype);
+
+    if (hasFanMode || !speedSchema || !activeSchema) {
+      if (existing) {
+        this.accessory.removeService(existing);
+      }
+      return;
+    }
+
+    const name = 'Fan Speed';
+    const service = existing || this.accessory.addService(this.Service.Fanv2, name, subtype);
+    service.setCharacteristic(this.Characteristic.ConfiguredName, name);
+
+    const { INACTIVE, ACTIVE } = this.Characteristic.Active;
+    service.getCharacteristic(this.Characteristic.Active)
+      .onGet(() => (this.getStatus(activeSchema.code)?.value === true) ? ACTIVE : INACTIVE)
+      .onSet(async value => {
+        await this.sendCommands([{ code: activeSchema.code, value: value === ACTIVE }], true);
+      });
+
+    configureRotationSpeedLevel(this, service, speedSchema, ['auto']);
   }
 
   mainService() {

--- a/src/shared/accessory/characteristic/RotationSpeed.ts
+++ b/src/shared/accessory/characteristic/RotationSpeed.ts
@@ -88,7 +88,10 @@ function configureRotationSpeedEnum(
   const rotationSpeedProperty = enumToPercentageProperty(cloneProperty);
 
   const onGetHandler = () => {
-    const status = accessory.getStatus(schema.code)!;
+    // A device can omit this DP entirely; indexOf(undefined) yields -1, which limit()
+    // clamps to the minimum, instead of throwing inside the read handler and taking
+    // the whole accessory offline in HomeKit.
+    const status = accessory.getStatus(schema.code);
     const index = range.indexOf(status?.value as string);
     const level = index + 1;
     const hapValue = level * rotationSpeedProperty.minStep!;
@@ -134,8 +137,11 @@ export function configureRotationSpeedLevel(
   accessory.log.debug('Set props for RotationSpeed:', props);
 
   const onGetHandler = () => {
-    const status = accessory.getStatus(schema.code)!;
-    const index = range.indexOf(status.value as string);
+    // A device can omit this DP entirely; indexOf(undefined) yields -1, which limit()
+    // clamps to the minimum, instead of throwing inside the read handler and taking
+    // the whole accessory offline in HomeKit.
+    const status = accessory.getStatus(schema.code);
+    const index = range.indexOf(status?.value as string);
     return limit(index + 1, props.minValue, props.maxValue);
   };
 

--- a/test/airConditioner.swing.test.ts
+++ b/test/airConditioner.swing.test.ts
@@ -7,8 +7,9 @@ import AirConditionerAccessory from '../src/shared/accessory/AirConditionerAcces
  *  - one Switch per swing axis the device reports
  *  - a Fanv2 "Fan Speed" tile when the device has no fan mode
  *
- * Both exist because the Home app does not render SwingMode or RotationSpeed on a
- * HeaterCooler service, so those DPs are otherwise unreachable from the Home app.
+ * Both exist because the Home app does not offer SwingMode or RotationSpeed as controls
+ * on a HeaterCooler service (it does on a fan service), leaving those DPs unreachable on
+ * an air conditioner that has no fan mode.
  */
 
 const SWITCH_UUID = 'Switch';

--- a/test/airConditioner.swing.test.ts
+++ b/test/airConditioner.swing.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import AirConditionerAccessory from '../src/shared/accessory/AirConditionerAccessory';
+
+/**
+ * Coverage for the extra services an air conditioner publishes:
+ *
+ *  - one Switch per swing axis the device reports
+ *  - a Fanv2 "Fan Speed" tile when the device has no fan mode
+ *
+ * Both exist because the Home app does not render SwingMode or RotationSpeed on a
+ * HeaterCooler service, so those DPs are otherwise unreachable from the Home app.
+ */
+
+const SWITCH_UUID = 'Switch';
+const FANV2_UUID = 'Fanv2';
+const HUMIDIFIER_UUID = 'HumidifierDehumidifier';
+
+interface FakeService {
+  UUID: string;
+  displayName?: string;
+  subtype?: string;
+  characteristics: Record<string, unknown>;
+  handlers: Record<string, { get?: () => unknown; set?: (v: unknown) => unknown }>;
+  getCharacteristic: (c: unknown) => unknown;
+  setCharacteristic: (c: unknown, v: unknown) => FakeService;
+  updateCharacteristic?: (c: unknown, v: unknown) => FakeService;
+}
+
+/** Minimal service/accessory doubles: enough to observe what gets published. */
+function makeService(uuid: string, displayName?: string, subtype?: string): FakeService {
+  const service: FakeService = {
+    UUID: uuid,
+    displayName,
+    subtype,
+    characteristics: {},
+    handlers: {},
+    getCharacteristic(characteristic: any) {
+      const key = String(characteristic?.name ?? characteristic);
+      service.handlers[key] = service.handlers[key] || {};
+      const chain: any = {
+        onGet: (fn: any) => { service.handlers[key].get = fn; return chain; },
+        onSet: (fn: any) => { service.handlers[key].set = fn; return chain; },
+        updateValue: () => chain,
+        setProps: () => chain,
+      };
+      return chain;
+    },
+    setCharacteristic(characteristic: any, value: unknown) {
+      service.characteristics[String(characteristic?.name ?? characteristic)] = value;
+      return service;
+    },
+  };
+  return service;
+}
+
+function makeAccessory() {
+  const services: FakeService[] = [];
+  return {
+    services,
+    context: { deviceID: 'dev' },
+    displayName: 'AC',
+    getService: (type: any) => services.find(s => s.UUID === (type?.UUID ?? type) && !s.subtype),
+    getServiceById: (type: any, subtype: string) =>
+      services.find(s => s.UUID === (type?.UUID ?? type) && s.subtype === subtype),
+    addService: (type: any, displayName?: string, subtype?: string) => {
+      const svc = makeService(type?.UUID ?? type, displayName, subtype);
+      services.push(svc);
+      return svc;
+    },
+    removeService: (svc: FakeService) => {
+      const i = services.indexOf(svc);
+      if (i >= 0) {
+        services.splice(i, 1);
+      }
+    },
+  };
+}
+
+/**
+ * Build an accessory instance without running the real constructor, then drive only
+ * the methods under test.  Keeps the test focused on which services get published.
+ */
+function buildAccessory(opts: {
+  swingCodes?: string[];
+  modeRange?: string[];
+  speedCode?: string | null;
+  statuses?: Record<string, unknown>;
+}) {
+  const { swingCodes = [], modeRange = ['cold', 'heat', 'auto'], speedCode = 'fan_speed_enum', statuses = {} } = opts;
+
+  const accessory = makeAccessory();
+  const schemas: Record<string, any> = {
+    switch: { code: 'switch', property: {} },
+    mode: { code: 'mode', property: { range: modeRange } },
+  };
+  for (const code of swingCodes) {
+    schemas[code] = { code, property: {} };
+  }
+  if (speedCode) {
+    schemas[speedCode] = { code: speedCode, property: { range: ['level_auto', 'level_1', 'level_2'] } };
+  }
+
+  const sent: Array<Array<{ code: string; value: unknown }>> = [];
+
+  // The real constructor needs a platform, a homebridge API and a device; assembling
+  // the few members these two methods touch keeps the test focused on which services
+  // get published.  Several of them are readonly, hence the single Object.assign.
+  const ac: any = Object.assign(Object.create(AirConditionerAccessory.prototype), {
+    accessory,
+    Service: {
+      Switch: { UUID: SWITCH_UUID },
+      Fanv2: { UUID: FANV2_UUID },
+      HumidifierDehumidifier: { UUID: HUMIDIFIER_UUID },
+    },
+    Characteristic: {
+      On: { name: 'On' },
+      Active: { name: 'Active', ACTIVE: 1, INACTIVE: 0 },
+      ConfiguredName: { name: 'ConfiguredName' },
+      RotationSpeed: { name: 'RotationSpeed' },
+    },
+    log: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    getSchema: (...codes: string[]) => codes.map(c => schemas[c]).find(Boolean),
+    getStatus: (code: string) => (code in statuses ? { code, value: statuses[code] } : undefined),
+    sendCommands: jest.fn(async (commands: any) => { sent.push(commands); }),
+  });
+
+  return { ac, accessory, sent };
+}
+
+describe('AirConditionerAccessory swing switches', () => {
+  test('publishes one switch per reported axis, with a name', () => {
+    const { ac, accessory } = buildAccessory({ swingCodes: ['switch_vertical', 'switch_horizontal'] });
+    ac.configureSwingSwitches();
+
+    const switches = accessory.services.filter(s => s.UUID === SWITCH_UUID);
+    expect(switches.map(s => s.subtype)).toEqual(['swing-switch_vertical', 'swing-switch_horizontal']);
+    // Without ConfiguredName the Home app shows both tiles under the accessory name.
+    expect(switches.map(s => s.characteristics.ConfiguredName)).toEqual(['Vertical Swing', 'Horizontal Swing']);
+  });
+
+  test('publishes nothing when the device reports no swing DP', () => {
+    const { ac, accessory } = buildAccessory({ swingCodes: [] });
+    ac.configureSwingSwitches();
+
+    expect(accessory.services.filter(s => s.UUID === SWITCH_UUID)).toHaveLength(0);
+  });
+
+  test('only the axes the device reports get a switch', () => {
+    const { ac, accessory } = buildAccessory({ swingCodes: ['switch_vertical'] });
+    ac.configureSwingSwitches();
+
+    const switches = accessory.services.filter(s => s.UUID === SWITCH_UUID);
+    expect(switches).toHaveLength(1);
+    expect(switches[0].subtype).toBe('swing-switch_vertical');
+  });
+
+  test('reads and writes the matching DP', async () => {
+    const { ac, accessory, sent } = buildAccessory({
+      swingCodes: ['switch_vertical'],
+      statuses: { switch_vertical: true },
+    });
+    ac.configureSwingSwitches();
+
+    const svc = accessory.services.find(s => s.subtype === 'swing-switch_vertical')!;
+    expect(svc.handlers.On.get!()).toBe(true);
+
+    await svc.handlers.On.set!(false);
+    expect(sent).toEqual([[{ code: 'switch_vertical', value: false }]]);
+  });
+
+  test('drops a switch when the device stops reporting that axis', () => {
+    const { ac, accessory } = buildAccessory({ swingCodes: ['switch_vertical', 'switch_horizontal'] });
+    ac.configureSwingSwitches();
+    expect(accessory.services.filter(s => s.UUID === SWITCH_UUID)).toHaveLength(2);
+
+    // Same accessory, but the device now reports only the vertical louvre
+    const reduced = buildAccessory({ swingCodes: ['switch_vertical'] });
+    reduced.accessory.services.push(...accessory.services);
+    reduced.ac.configureSwingSwitches();
+
+    const remaining = reduced.accessory.services.filter(s => s.UUID === SWITCH_UUID);
+    expect(remaining.map(s => s.subtype)).toEqual(['swing-switch_vertical']);
+  });
+});
+
+describe('AirConditionerAccessory fan-speed tile', () => {
+  test('publishes a named Fanv2 when the device has no fan mode', () => {
+    const { ac, accessory } = buildAccessory({ modeRange: ['cold', 'heat', 'auto'] });
+    ac.configureFanSpeedTile();
+
+    const fans = accessory.services.filter(s => s.UUID === FANV2_UUID);
+    expect(fans).toHaveLength(1);
+    expect(fans[0].subtype).toBe('fan-speed');
+    expect(fans[0].characteristics.ConfiguredName).toBe('Fan Speed');
+  });
+
+  test('publishes nothing when the device already has a fan mode', () => {
+    // configureFan() already provides a Fanv2 with RotationSpeed in that case.
+    const { ac, accessory } = buildAccessory({ modeRange: ['cold', 'fan', 'auto'] });
+    ac.configureFanSpeedTile();
+
+    expect(accessory.services.filter(s => s.UUID === FANV2_UUID)).toHaveLength(0);
+  });
+
+  test('publishes nothing when the device reports no fan-speed DP', () => {
+    const { ac, accessory } = buildAccessory({ speedCode: null });
+    ac.configureFanSpeedTile();
+
+    expect(accessory.services.filter(s => s.UUID === FANV2_UUID)).toHaveLength(0);
+  });
+
+  test('Active drives the power DP and never sends a mode change', async () => {
+    // Sending a mode alongside the speed is what made units flip into fan mode when
+    // the slider moved.
+    const { ac, accessory, sent } = buildAccessory({ statuses: { switch: false } });
+    ac.configureFanSpeedTile();
+
+    const fan = accessory.services.find(s => s.subtype === 'fan-speed')!;
+    expect(fan.handlers.Active.get!()).toBe(0);
+
+    await fan.handlers.Active.set!(1);
+    expect(sent).toEqual([[{ code: 'switch', value: true }]]);
+    expect(JSON.stringify(sent)).not.toContain('mode');
+  });
+});

--- a/test/airConditioner.test.ts
+++ b/test/airConditioner.test.ts
@@ -133,13 +133,20 @@ const createMockPlatform = (): any => {
   };
 };
 
+// Services created with a subtype, keyed as `${serviceUUID}:${subtype}`
+const subtypeServices = new Map<string, any>();
+
 // Create mock accessory
 const createMockAccessory = (): any => ({
   context: { deviceID: 'test-device-001' },
   displayName: 'Test Air Conditioner',
   services: [],
   getService: jest.fn(),
+  // Real PlatformAccessory exposes these too; services with a subtype are looked up
+  // and removed through them.
+  getServiceById: jest.fn(),
   addService: jest.fn(),
+  removeService: jest.fn(),
 });
 
 const createMockCharacteristic = () => {
@@ -234,6 +241,9 @@ describe('AirConditionerAccessory', () => {
       'Battery': mockBatteryService,
     };
 
+    // Tracks services created with a subtype, so getServiceById can resolve them
+    subtypeServices.clear();
+
     // Both getService and addService should return the same mock services
     accessory.getService.mockImplementation((serviceType: any) => {
       const serviceName = typeof serviceType === 'string' ? serviceType : serviceType?.UUID;
@@ -242,7 +252,25 @@ describe('AirConditionerAccessory', () => {
 
     accessory.addService.mockImplementation((serviceType: any, ...args: any[]) => {
       const serviceName = typeof serviceType === 'string' ? serviceType : serviceType?.UUID;
-      return serviceMap[serviceName] || mockAccessoryInformationService; // Default to AccessoryInformation
+      const created = serviceMap[serviceName] || mockAccessoryInformationService;
+      // args = [displayName, subtype]; remember the subtype so getServiceById finds it
+      if (args.length > 1) {
+        subtypeServices.set(`${serviceName}:${args[1]}`, created);
+      }
+      return created;
+    });
+
+    accessory.getServiceById.mockImplementation((serviceType: any, subtype: string) => {
+      const serviceName = typeof serviceType === 'string' ? serviceType : serviceType?.UUID;
+      return subtypeServices.get(`${serviceName}:${subtype}`);
+    });
+
+    accessory.removeService.mockImplementation((service: any) => {
+      for (const [key, value] of subtypeServices.entries()) {
+        if (value === service) {
+          subtypeServices.delete(key);
+        }
+      }
     });
 
     // Mock characteristic getters


### PR DESCRIPTION
## Summary

Follow-up to #49, from continuing to live with the same device (Daikin air conditioner, **WiFiKit-II-DK**, protocol 3.5, `category: kt`).

With #49 in place the connection is solid — but three things kept the unit's **louvres and blower speed out of reach in the Home app**, and one null-guard from #49 turned out to be incomplete. All four are fixed here, with 9 new test cases.

| | before | after |
|---|---|---|
| Swing control in the Home app | none at all (vertical swing was running, invisible) | two switches, readable and settable |
| Fan speed in the Home app | only reachable via a tile that also changed the mode | its own tile, speed only |
| Moving the speed slider | switched the unit into **fan mode** | sends `fan_speed_enum` and nothing else |
| Device that omits its fan-speed DP | whole accessory went **"No Response"** | reads fall back to the minimum |

---

## 1. Swing was never wired up

`configureSwingMode` has been present but commented out on all three services since the refactor in 4a36d90:

```ts
// configureSwingMode(this, service, this.getSchema(...SCHEMA_CODE.SWING));
```

`SwingMode.ts` itself is complete and works. This enables it on the air conditioner service and makes `SCHEMA_CODE.SWING` prefer `switch_vertical`, since that is the axis most units expose and the one people reach for.

I left the dehumidifier and fan services commented as they are — I have no device to test those paths against, and I would rather not enable code I cannot exercise.

## 2. The Home app does not surface SwingMode or RotationSpeed on a HeaterCooler

This one cost me a while. After enabling `configureSwingMode` I could see the characteristic in the accessory:

```
HeaterCooler characteristics:
  - Active = 0
  - Current Heater-Cooler State = 0
  - Target Heater-Cooler State = 2
  - Current Temperature = 31
  - Rotation Speed = 0
  - Cooling Threshold Temperature = 25.5
  - Heating Threshold Temperature = 25.5
  - Swing Mode = 0          ← present and correct
```

…and still no swing control appeared in the Home app — not in the main view, not in the detail view. Same story for `Rotation Speed`: present on the service with a correct value, never drawn.

To be precise about the scope, since this came up in review: `RotationSpeed` and `SwingMode` *are* optional characteristics of `HeaterCooler` in HAP, and the Home app *does* draw `RotationSpeed` for fan services (`Fan`/`Fanv2`) under Details. What I am reporting is narrower — on a **HeaterCooler** neither is offered as a control, verified on one device and one iOS version. I have no second HeaterCooler accessory or other HomeKit client to compare against, so treat that as a single observation rather than a general statement about the app.

Net effect on this device: **vertical swing was physically running** (`switch_vertical` reporting `true`, the louvre visibly moving) with no way to see or change it from the Home app, and the blower speed was equally unreachable.

Rather than leave working DPs inaccessible, each is published as a service type the Home app does draw:

**`configureSwingSwitches()`** — one `Switch` per swing axis the device reports, subtypes `swing-switch_vertical` and `swing-switch_horizontal`. HeaterCooler carries only one `SwingMode`, so this is also the only way to expose a second axis. A switch is removed again if the device stops reporting that axis.

**`configureFanSpeedTile()`** — a `Fanv2` with subtype `fan-speed` carrying the blower speed, **only when the device has no fan mode**. Devices with a fan mode already get a Fanv2 with `RotationSpeed` from `configureFan()`, so nothing changes for them.

Its `Active` mirrors the power DP and deliberately never sends a mode change:

```ts
service.getCharacteristic(this.Characteristic.Active)
  .onGet(() => (this.getStatus(activeSchema.code)?.value === true) ? ACTIVE : INACTIVE)
  .onSet(async value => {
    await this.sendCommands([{ code: activeSchema.code, value: value === ACTIVE }], true);
  });
```

`configureFan()` sends `{ mode: fanCode }` alongside, which is right for a fan *mode* — but because both services bind the same fan-speed DP and the Home app puts them side by side, nudging what looks like a speed slider flipped the unit into fan mode. That was the symptom that started this investigation:

```
Sending command (local): switch=true, mode=cold, fan_speed_enum=level_2
                                     ^^^^^^^^^ unwanted
```

Every new tile also sets `ConfiguredName`. Without it the Home app labels them with the accessory name, so two swing switches are indistinguishable — I confirmed that the hard way before adding it.

## 3. Stale services lingered

`configureFan()` and `configureDehumidifier()` return early when the device has no such mode, but a service created by an earlier run stays in the accessory. Concretely: after narrowing the mode range on my device, the Fanv2 remained and kept showing a slider bound to the fan-speed DP, mode change included. Both now remove the leftover service.

The lookup is deliberately

```ts
this.accessory.services.find(s => s.UUID === this.Service.Fanv2.UUID && !s.subtype)
```

rather than `getService(this.Service.Fanv2)` — `getService()` ignores subtypes, so it matches the `fan-speed` tile added above and deletes it. I hit exactly that while developing this: the tile appeared in the log and then vanished from the Home app.

## 4. A guard missed in #49

`configureRotationSpeedLevel` still dereferenced `status.value` without a null check, while the other three RotationSpeed variants were guarded in #49:

```
 45:    const value = (status?.value as number ?? 0) / multiple;   ← guarded
 92:    const index = range.indexOf(status?.value as string);      ← guarded
138:    const index = range.indexOf(status.value as string);       ← missed
172:      return (status?.value as boolean) ? 100 : 0;             ← guarded
```

Line 138 is the variant `AirConditionerAccessory` actually calls, so a device that does not report its fan-speed DP threw inside the read handler — and HomeKit marks the **whole** accessory "No Response" when a read throws, while writes keep working.

That was my mistake in #49: a text replacement that hit only the first of two matching call sites. The new test suite is what caught it, which felt like a decent argument for the tests being worth having.

---

## Testing

- `npm test` — **982 passing** (973 on `beta-3.0.0`), with the same 2 pre-existing suite failures (`home.test.ts`, `custom.test.ts` need `~/.homebridge-dev/config.json`).
- `npm run lint` and `npm run build` — clean.
- **`test/airConditioner.swing.test.ts` (new, 9 cases):**
  - a switch per reported axis, with the right subtype and `ConfiguredName`
  - nothing published when the device reports no swing DP
  - only the axes the device reports get a switch
  - the switch reads and writes the matching DP
  - a switch is dropped when its axis disappears
  - the fan tile appears only when there is no fan mode, and not when the fan-speed DP is missing
  - the fan tile's `Active` drives the power DP and **emits no mode change** (asserted on the command payload)
- `test/airConditioner.test.ts` — the mock accessory gained `getServiceById` / `removeService` to match the real `PlatformAccessory` API, plus a small registry so subtype lookups resolve.

**On hardware**, after deploying these changes the Home app shows: the air conditioner, `Fan Speed`, `Vertical Swing`, `Horizontal Swing`. Moving the speed slider produces only `fan_speed_enum` commands, all over the local connection, with no timeouts and no cloud fallback:

```
Sending command (local): switch=true, fan_speed_enum=level_2
Sending command (local): fan_speed_enum=level_1
Sending command (local): switch=true, fan_speed_enum=level_quiet
Sending command (local): fan_speed_enum=level_5
```

## Notes / open questions

- **Layout change for existing users.** Devices without a fan mode gain a `Fan Speed` tile, and any device reporting a swing DP gains one or two switches. I think that is the right default, since those DPs are otherwise unreachable from the Home app — but it is your call. Happy to put both behind config flags (`exposeSwingSwitches`, `exposeFanSpeedTile`) with `config.schema.json` entries if you would prefer opt-in.
- **`ignoreValues: ['auto']` never matches.** `configureRotationSpeedLevel(..., ['auto'])` is meant to drop the auto step, but this device (and, I suspect, most Tuya ACs) reports `level_auto`, so nothing is filtered and speed 1 means auto rather than level 1. I have **not** touched it here: fixing it shifts every speed step by one for every existing user, which seems like your decision rather than mine. Reporting it in case it is news.
- The dehumidifier and fan services still have `configureSwingMode` commented out, as noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

