### PR TITLE
Fix remote unlock for Bluetooth Smart Lock (ms): surface Smart Lock API failures instead of discarding them

### DIFF
--- a/src/accessory/LockAccessory.ts
+++ b/src/accessory/LockAccessory.ts
@@ -1,11 +1,72 @@
+import { CharacteristicValue } from 'homebridge';
+
 import BaseAccessory from './BaseAccessory';
+import { TuyaDeviceStatus } from '../device/TuyaDevice';
+import { maskSecret } from '../util/util';
 
 const SCHEMA_CODE = {
   LOCK_CURRENT_STATE: ['open_close', 'closed_opened', 'lock_motor_state'],
   LOCK_TARGET_STATE: ['lock_motor_state'],
 };
 
+/**
+ * Tuya's "Door lock equipment is not online!". For a Bluetooth lock behind a
+ * gateway this is not a permanent error — it means the request arrived while
+ * the lock was not holding its link.
+ */
+const DEVICE_NOT_ONLINE_CODE = 2312;
+
+/**
+ * Measured on a Tuya BLE lock (category `ms`) behind a Tuya gateway, from the
+ * device's own connection log over six hours:
+ *
+ *   19:39:51 online -> 19:43:39 offline   (window 3m48s, then 34m offline)
+ *   20:18:21 online -> 20:19:37 offline   (window 1m16s, then 19m offline)
+ *   20:38:56 online -> 20:40:08 offline   (window 1m12s, then 24m offline)
+ *   21:04:42 online -> 21:06:47 offline   (window 2m05s, then 72m offline)
+ *
+ * The lock holds its link for one or two minutes and drops it for twenty to
+ * seventy. A door-operate sent into one of those gaps is rejected with 2312,
+ * and the lock came back online roughly 40s after a burst of four rejected
+ * attempts. So a 2312 is a closed window, not a failure: keep asking across
+ * one plausible window rather than giving up on the first no.
+ *
+ * Four attempts inside seven seconds caught nothing, which is why this is
+ * measured in minutes.
+ */
+const RETRY_WINDOW = 90 * 1000;
+const RETRY_INTERVAL = 10 * 1000;
+
+/**
+ * How long HomeKit's `LockTargetState` stays pinned to the value the user
+ * asked for, while we wait for the device to report its real state over MQTT.
+ * Without this, `updateAllValues()` snaps the target back to the reported
+ * state on the very next status event, and the Home app then refuses to
+ * re-send an identical target on the next tap.
+ *
+ * It has to outlast the retry window, or the Home app would drop back to
+ * "locked" while the plugin is still trying.
+ */
+const PENDING_TARGET_STATE_TIMEOUT = RETRY_WINDOW + 15 * 1000;
+
+/** What one attempt at the two-step Smart Lock flow concluded. */
+type DoorOperationOutcome = 'ok' | 'unreachable' | 'failed';
+
+/**
+ * Tuya Smart Lock (categories `ms`, `jtmspro`), including Bluetooth locks
+ * reachable through a Tuya gateway.
+ *
+ * Unlocking does not go through the regular `/devices/{id}/commands` DP write.
+ * It uses the Smart Lock Open Service:
+ *   1. POST /v1.0/smart-lock/devices/{id}/password-ticket      -> ticket_id
+ *   2. POST /v1.0/smart-lock/devices/{id}/password-free/door-operate
+ * See TuyaDeviceManager.getLockTemporaryKey / sendLockCommands.
+ */
 export default class LockAccessory extends BaseAccessory {
+
+  private pendingTargetState?: CharacteristicValue;
+  private pendingTargetStateTimer?: ReturnType<typeof setTimeout>;
+  private retryTimer?: ReturnType<typeof setTimeout>;
 
   requiredSchema() {
     return [SCHEMA_CODE.LOCK_CURRENT_STATE];
@@ -24,36 +85,286 @@ export default class LockAccessory extends BaseAccessory {
   configureLockCurrentState() {
     const schema = this.getSchema(...SCHEMA_CODE.LOCK_CURRENT_STATE);
     if (!schema) {
+      this.log.warn('[Lock] No schema found for LockCurrentState (tried: %s). State reporting is disabled.',
+        SCHEMA_CODE.LOCK_CURRENT_STATE.join(', '));
       return;
     }
 
     const { UNSECURED, SECURED } = this.Characteristic.LockCurrentState;
     this.mainService().getCharacteristic(this.Characteristic.LockCurrentState)
       .onGet(() => {
-        const status = this.getStatus(schema.code)!;
+        const status = this.getStatus(schema.code);
+        if (!status) {
+          this.log.debug('[Lock] LockCurrentState: no status reported for dp `%s` yet, assuming SECURED.', schema.code);
+          return SECURED;
+        }
         return (status.value as boolean) ? UNSECURED : SECURED;
       });
+
+    this.log.debug('[Lock] LockCurrentState is driven by dp `%s`.', schema.code);
   }
 
   configureLockTargetState() {
     const schema = this.getSchema(...SCHEMA_CODE.LOCK_TARGET_STATE);
     if (!schema) {
+      this.log.warn('[Lock] No schema found for LockTargetState (tried: %s). '
+        + 'Remote lock/unlock from HomeKit is DISABLED for this device.',
+      SCHEMA_CODE.LOCK_TARGET_STATE.join(', '));
       return;
     }
 
     const { UNSECURED, SECURED } = this.Characteristic.LockTargetState;
     this.mainService().getCharacteristic(this.Characteristic.LockTargetState)
       .onGet(() => {
-        const status = this.getStatus(schema.code)!;
+        if (this.pendingTargetState !== undefined) {
+          return this.pendingTargetState;
+        }
+        const status = this.getStatus(schema.code);
+        if (!status) {
+          return SECURED;
+        }
         return (status.value as boolean) ? UNSECURED : SECURED;
       })
       .onSet(async value => {
-        const res = await this.deviceManager.getLockTemporaryKey(this.device.id);
-        if (!res.success) {
-          return;
-        }
-        await this.deviceManager.sendLockCommands(this.device.id, res.result.ticket_id, (value === UNSECURED));
+        await this.setLockTargetState(value);
       });
+
+    this.log.debug('[Lock] LockTargetState handler registered (dp `%s`). '
+      + 'Writes are routed through the Tuya Smart Lock Open Service.', schema.code);
+  }
+
+  /**
+   * HomeKit -> Tuya. Never reports success optimistically: `LockCurrentState`
+   * keeps reflecting whatever the device last reported, and only a real device
+   * status update moves it.
+   */
+  private async setLockTargetState(value: CharacteristicValue) {
+    const { UNSECURED } = this.Characteristic.LockTargetState;
+    const open = (value === UNSECURED);
+
+    this.log.info('[Lock] HomeKit requested target state: %s', open ? 'UNSECURED' : 'SECURED');
+
+    // A BLE sub-device behind a gateway is routinely reported as `online:
+    // false` by Tuya while remote unlocking still works — the gateway is what
+    // has to be online. So warn, but let the Smart Lock API be the authority.
+    if (this.device.online === false) {
+      this.log.warn('[Lock] Tuya reports this device as offline. Trying the %s anyway '
+        + '(BLE sub-devices are often reported offline while the gateway relays fine).',
+      open ? 'unlock' : 'lock');
+    }
+
+    this.setPendingTargetState(value);
+
+    const outcome = await this.performDoorOperation(open);
+
+    if (outcome === 'failed') {
+      this.clearPendingTargetState();
+      this.updateAllValues();
+      throw this.communicationError();
+    }
+
+    if (outcome === 'unreachable') {
+      // Deliberately not an error to HomeKit, and deliberately not awaited.
+      // A HAP write that takes 90s times out on the controller no matter what
+      // it eventually returns, so the first attempt answers and the rest runs
+      // behind it: the Home app shows "Unlocking…" while the pending target
+      // state holds, and either the device reports the unlock or the state
+      // falls back to what the lock actually says.
+      this.log.info('[Lock] Lock is not reachable through the gateway right now. '
+        + 'Retrying for up to %ds in the background — HomeKit will show the real state '
+        + 'once the lock answers.', RETRY_WINDOW / 1000);
+      this.scheduleRetry(open, Date.now() + RETRY_WINDOW);
+      return;
+    }
+
+    this.log.info('[Lock] Door operation accepted. Waiting for the device to report its real state '
+      + '(HomeKit is NOT marked as %s yet).', open ? 'unlocked' : 'locked');
+  }
+
+  /**
+   * Keeps asking until the lock's next connection window opens, the deadline
+   * passes, or something cancels the pending state (a device report, or the
+   * user asking for the opposite).
+   */
+  private scheduleRetry(open: boolean, deadline: number) {
+    this.clearRetryTimer();
+
+    this.retryTimer = setTimeout(async () => {
+      if (this.pendingTargetState === undefined) {
+        this.log.debug('[Lock] Retry cancelled: no target state is pending any more.');
+        return;
+      }
+
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        this.log.warn('[Lock] Gave up after %ds: the lock never became reachable through the gateway. '
+          + 'HomeKit is falling back to the last state the lock reported.', RETRY_WINDOW / 1000);
+        this.clearPendingTargetState();
+        this.updateAllValues();
+        return;
+      }
+
+      this.log.debug('[Lock] Retrying the door operation (%ds left in the window)...', Math.round(remaining / 1000));
+      const outcome = await this.performDoorOperation(open);
+
+      if (outcome === 'ok') {
+        this.log.info('[Lock] Door operation accepted on retry. Waiting for the device to report its real state.');
+        return;
+      }
+
+      if (outcome === 'failed') {
+        this.clearPendingTargetState();
+        this.updateAllValues();
+        return;
+      }
+
+      this.scheduleRetry(open, deadline);
+    }, RETRY_INTERVAL);
+
+    this.retryTimer.unref?.();
+  }
+
+  private clearRetryTimer() {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = undefined;
+    }
+  }
+
+  /**
+   * Runs the two-step Smart Lock Open Service flow once.
+   * Reports the outcome — after logging why — instead of throwing, so the
+   * caller owns the single HomeKit-facing error and the retry decision.
+   */
+  private async performDoorOperation(open: boolean): Promise<DoorOperationOutcome> {
+    this.log.debug('[Lock] Requesting Tuya password ticket...');
+
+    const ticketRes = await this.deviceManager.getLockTemporaryKey(this.device.id);
+    if (!ticketRes.success) {
+      this.log.error('[Lock] password-ticket failed:\n  success=false\n  code=%s\n  msg=%s',
+        ticketRes.code, ticketRes.msg);
+      return 'failed';
+    }
+
+    const ticketID = ticketRes.result?.ticket_id;
+    if (!ticketID) {
+      this.log.error('[Lock] password-ticket returned success but no ticket_id. '
+        + 'Result keys: %s', Object.keys(ticketRes.result || {}).join(', ') || '<empty>');
+      return 'failed';
+    }
+
+    this.log.debug('[Lock] password-ticket response:\n  success=true\n  ticket_id=%s\n  expire_time=%s',
+      maskSecret(ticketID), ticketRes.result?.expire_time);
+
+    this.log.debug('[Lock] Sending door operation:\n  open=%s', open);
+
+    const operateRes = await this.deviceManager.sendLockCommands(this.device.id, ticketID, open);
+
+    // Tuya may answer `success: true` with `result: false`, meaning the cloud
+    // accepted the request but the lock refused the operation.
+    if (!operateRes.success) {
+      // 2312 is the lock being between connection windows. It is the normal
+      // case for a BLE lock, so it is logged as a warning and left to the
+      // retry loop — and the diagnostics lookup is skipped, or every attempt
+      // would spend an extra API call re-reading settings that cannot have
+      // changed since the last one.
+      if (operateRes.code === DEVICE_NOT_ONLINE_CODE) {
+        this.log.warn('[Lock] door-operate rejected:\n  success=false\n  code=%s\n  msg=%s',
+          operateRes.code, operateRes.msg);
+        return 'unreachable';
+      }
+
+      this.log.error('[Lock] door-operate failed:\n  success=false\n  code=%s\n  msg=%s',
+        operateRes.code, operateRes.msg);
+      await this.logRemoteUnlockDiagnostics();
+      return 'failed';
+    }
+
+    if (operateRes.result === false) {
+      this.log.error('[Lock] door-operate rejected by the device:\n  success=true\n  result=false');
+      await this.logRemoteUnlockDiagnostics();
+      return 'failed';
+    }
+
+    this.log.debug('[Lock] door-operate response:\n  success=true\n  result=%o', operateRes.result);
+    return 'ok';
+  }
+
+  /**
+   * Best-effort diagnostics after a rejected door operation: tells the user
+   * which remote unlocking methods the lock actually exposes.
+   */
+  private async logRemoteUnlockDiagnostics() {
+    if (typeof this.deviceManager.getLockRemoteUnlockMethods !== 'function') {
+      return;
+    }
+
+    try {
+      const res = await this.deviceManager.getLockRemoteUnlockMethods(this.device.id);
+      if (!res.success) {
+        this.log.warn('[Lock] Could not read the supported remote unlocking methods: code=%s, msg=%s',
+          res.code, res.msg);
+        return;
+      }
+      this.log.warn('[Lock] Remote unlocking methods reported by this lock: %o', res.result);
+      this.log.warn('[Lock] If the list is empty, enable remote unlocking for this lock in the Tuya/Smart Life app.');
+    } catch (error) {
+      this.log.debug('[Lock] Remote unlocking methods lookup threw: %s', (error as Error).message);
+    }
+  }
+
+  async onDeviceStatusUpdate(status: TuyaDeviceStatus[]) {
+    const schema = this.getSchema(...SCHEMA_CODE.LOCK_CURRENT_STATE);
+    const update = schema && status.find(item => item.code === schema.code);
+
+    if (update) {
+      this.log.debug('[Lock] Device reported %s = %o', update.code, update.value);
+
+      if (this.pendingTargetState !== undefined) {
+        const { UNSECURED, SECURED } = this.Characteristic.LockTargetState;
+        const reported = (update.value as boolean) ? UNSECURED : SECURED;
+        if (reported === this.pendingTargetState) {
+          this.log.debug('[Lock] Device reached the requested state. Releasing the pending target state.');
+          this.clearPendingTargetState();
+        }
+      }
+    }
+
+    await super.onDeviceStatusUpdate(status);
+  }
+
+  private setPendingTargetState(value: CharacteristicValue) {
+    // A fresh request supersedes whatever was still being retried, including
+    // one going the opposite way.
+    this.clearRetryTimer();
+    this.pendingTargetState = value;
+
+    if (this.pendingTargetStateTimer) {
+      clearTimeout(this.pendingTargetStateTimer);
+    }
+    this.pendingTargetStateTimer = setTimeout(() => {
+      this.log.debug('[Lock] Timed out after %ds waiting for the device to report the requested state. '
+        + 'Falling back to the reported state.', PENDING_TARGET_STATE_TIMEOUT / 1000);
+      this.clearPendingTargetState();
+      this.updateAllValues();
+    }, PENDING_TARGET_STATE_TIMEOUT);
+
+    // Don't hold the event loop open.
+    this.pendingTargetStateTimer.unref?.();
+  }
+
+  private clearPendingTargetState() {
+    this.clearRetryTimer();
+    this.pendingTargetState = undefined;
+    if (this.pendingTargetStateTimer) {
+      clearTimeout(this.pendingTargetStateTimer);
+      this.pendingTargetStateTimer = undefined;
+    }
+  }
+
+  private communicationError() {
+    const { HapStatusError, HAPStatus } = this.platform.api.hap;
+    return new HapStatusError(HAPStatus.SERVICE_COMMUNICATION_FAILURE);
   }
 
 }

--- a/src/core/TuyaOpenAPI.ts
+++ b/src/core/TuyaOpenAPI.ts
@@ -12,6 +12,7 @@ import dns from 'dns';
 import { version } from '../../package.json';
 
 import { ExLogger, logger, PrefixLogger } from '../util/Logger';
+import { redactSensitive } from '../util/util';
 
 enum Endpoints {
   AMERICA = 'https://openapi.tuyaus.com',
@@ -334,17 +335,31 @@ export default class TuyaOpenAPI {
         requestOptions['agent'] = ipv4Agent;
       }
       const req = https.request(requestOptions, res => {
-        if (res.statusCode !== 200) {
-          this.log.warn('Status: %d %s', res.statusCode, res.statusMessage);
-          return;
-        }
         res.setEncoding('utf8');
         let rawData = '';
         res.on('data', (chunk) => {
           rawData += chunk;
         });
         res.on('end', () => {
-          resolve(JSON.parse(rawData));
+          // Never leave the promise unsettled: a non-200 used to hang the
+          // caller forever, which made API failures completely invisible.
+          if (res.statusCode !== 200) {
+            this.log.warn('Status: %d %s, path = %s, body = %s',
+              res.statusCode, res.statusMessage, path, rawData.slice(0, 512));
+          }
+
+          try {
+            resolve(JSON.parse(rawData));
+          } catch (error) {
+            resolve({
+              success: false,
+              result: rawData.slice(0, 512),
+              code: res.statusCode ?? -1,
+              msg: res.statusMessage ?? 'Invalid response body',
+              t: Date.now(),
+              tid: '',
+            });
+          }
         });
       });
 
@@ -359,7 +374,7 @@ export default class TuyaOpenAPI {
       req.end();
     }), undefined, {retriesMax: 10, interval: 100, exponential: true, factor: 2, jitter: 100});
 
-    this.log.debug('Response:\npath = %s\ndata = %s', path, JSON.stringify(res, null, 2));
+    this.log.debug('Response:\npath = %s\ndata = %s', path, JSON.stringify(redactSensitive(res), null, 2));
     if (res && res.success !== true && API_ERROR_MESSAGES[res.code]) {
       this.log.error(API_ERROR_MESSAGES[res.code]);
     }

--- a/src/device/TuyaDeviceManager.ts
+++ b/src/device/TuyaDeviceManager.ts
@@ -11,7 +11,7 @@ import TuyaDevice, {
   TuyaIRRemoteKeyListItem,
 } from './TuyaDevice';
 import { RTSPCameraConfig } from '../config';
-import { uuidFromSeed } from '../util/util';
+import { maskSecret, uuidFromSeed } from '../util/util';
 
 enum Events {
   DEVICE_ADD = 'DEVICE_ADD',
@@ -378,21 +378,59 @@ export default class TuyaDeviceManager extends EventEmitter {
   }
 
 
+  /**
+   * Smart Lock "Get Temporary Key".
+   * Applies to Wi-Fi, Zigbee, Bluetooth and hotel Zigbee locks.
+   * https://developer.tuya.com/en/docs/cloud/doorlock-api-remoteopen?id=Kbe2nm6j9hcsj
+   *
+   * The response carries a `ticket_key` (a 256-bit encryption key). It must
+   * never be written to the log.
+   */
   async getLockTemporaryKey(deviceID: string) {
     // const res = await this.api.post(`/v1.0/smart-lock/devices/${deviceID}/door-lock/password-ticket`);
+    this.log.debug('Requesting smart lock password ticket. devID = %s', deviceID);
     const res = await this.api.post(`/v1.0/smart-lock/devices/${deviceID}/password-ticket`);
     if (res.success === false) {
       this.log.warn('Get Temporary Pass failed. devID = %s, code = %s, msg = %s', deviceID, res.code, res.msg);
+    } else {
+      this.log.debug('Got smart lock password ticket. devID = %s, ticket_id = %s, expire_time = %s',
+        deviceID, maskSecret(res.result?.ticket_id), res.result?.expire_time);
     }
     return res;
   }
 
+  /**
+   * Smart Lock "Remote Locking and Unlocking Without Password".
+   * Applies to Wi-Fi, Zigbee, Bluetooth and hotel Zigbee locks.
+   * `open = true` unlocks, `open = false` locks.
+   * https://developer.tuya.com/en/docs/cloud/8b36eabd4d?id=Kayexavknr6dt
+   */
   async sendLockCommands(deviceID: string, ticketID: string, open: boolean) {
+    this.log.debug('Sending smart lock door operation. devID = %s, ticket_id = %s, open = %s',
+      deviceID, maskSecret(ticketID), open);
     const res = await this.api.post(`/v1.0/smart-lock/devices/${deviceID}/password-free/door-operate`, {
       device_id: deviceID,
       ticket_id: ticketID,
       open,
     });
+    if (res.success === false) {
+      this.log.warn('Send lock command failed. devID = %s, code = %s, msg = %s', deviceID, res.code, res.msg);
+    } else {
+      this.log.debug('Smart lock door operation accepted by Tuya Cloud. devID = %s, result = %o', deviceID, res.result);
+    }
+    return res;
+  }
+
+  /**
+   * Lists the remote unlocking methods a lock actually exposes.
+   * Applies to Zigbee and Bluetooth locks; used for diagnostics when a door
+   * operation is rejected.
+   */
+  async getLockRemoteUnlockMethods(deviceID: string) {
+    const res = await this.api.get(`/v1.0/devices/${deviceID}/door-lock/remote-unlocks`);
+    if (res.success === false) {
+      this.log.warn('Get remote unlock methods failed. devID = %s, code = %s, msg = %s', deviceID, res.code, res.msg);
+    }
     return res;
   }
 

--- a/src/util/Logger.ts
+++ b/src/util/Logger.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { EOL } from 'os';
 import util from 'util';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -27,7 +26,9 @@ export class PrefixLogger implements ExLogger {
     public log: Logger,
     public prefix: string = '',
     public debugMode = false,
-    private mask = !debugMode,
+    // Masking must NOT be tied to debugMode: debug is exactly when payloads
+    // (login bodies, access tokens, smart lock ticket keys) reach the log.
+    private mask = true,
   ) {
     this.debugMode = this.debugMode || process.argv.includes('-D') || process.argv.includes('--debug');
   }
@@ -74,16 +75,16 @@ export class PrefixLogger implements ExLogger {
     if (!this.mask || typeof str !== 'string') {
       return str;
     }
-    const regex_single = /'(password|token|access_?token|accessKey|tuyaKey|api_?key|secret)'\s*:\s*'[^']*'/gi;
-    const regex_double = /"(password|token|access_?token|accessKey|tuyaKey|api_?key|secret)"\s*:\s*"[^"]*"/gi;
-    const spilts = str.split(/\r\n|\n|\r/);
-    if (!spilts.some(s => regex_single.test(s)) && !spilts.some(s => regex_double.test(s))) {
-      return str;
-    }
-    const results = spilts
-      .map(a => a.replace(regex_single, '\'$1\': \'********\''))
-      .map(a => a.replace(regex_double, '"$1": "********"'));
-    return results.join(EOL);
+    // NOTE: a /g regex carries `lastIndex` across calls, so the previous
+    // `.some(s => re.test(s))` pre-check alternated true/false and let secrets
+    // through. `String.replace` resets `lastIndex` itself, so just replace.
+    const KEYS = 'password|token|access_?token|refresh_?token|accessKey|access_?key'
+      + '|tuyaKey|api_?key|secret|ticket_key|ticket_id|sign';
+    const regex_single = new RegExp(`'(${KEYS})'\\s*:\\s*'[^']*'`, 'gi');
+    const regex_double = new RegExp(`"(${KEYS})"\\s*:\\s*"[^"]*"`, 'gi');
+    return str
+      .replace(regex_single, '\'$1\': \'********\'')
+      .replace(regex_double, '"$1": "********"');
   }
 
   private maskingValue(obj: any) {
@@ -91,7 +92,7 @@ export class PrefixLogger implements ExLogger {
       return obj;
     }
     const cloneObj = cloneDeep(obj);
-    const regex = /(password|token|access_?token|accessKey|tuyakey|api_?key|secret)/i;
+    const regex = /(password|token|access_?token|refresh_?token|accessKey|access_?key|tuyakey|api_?key|secret|ticket_key|ticket_id|sign)/i;
     for (const key in cloneObj) {
       const value = cloneObj[key];
       if (typeof value === 'function') {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -114,3 +114,52 @@ function updateBuffer(buf: Buffer, byteIndex: number, value: number | Buffer | A
 
   return buf;
 }
+/**
+ * Keys whose values must never reach the log, no matter which log level is
+ * active. Note that `PrefixLogger` disables its own masking in debug mode
+ * (`mask = !debugMode`), so redaction has to happen at the call site.
+ */
+const SENSITIVE_KEY_PATTERN = /(password|secret|access_?key|access_?token|refresh_?token|ticket_key|api_?key|tuya_?key)/i;
+
+/**
+ * Mask an identifier that is not secret enough to print, but useful enough to
+ * correlate log lines (e.g. a smart lock `ticket_id`).
+ */
+export function maskSecret(value?: string | number | null, visible = 4): string {
+  if (value === undefined || value === null) {
+    return '<none>';
+  }
+  const str = `${value}`;
+  if (str.length === 0) {
+    return '<empty>';
+  }
+  if (str.length <= visible) {
+    return '***';
+  }
+  return `***${str.slice(-visible)}`;
+}
+
+/**
+ * Deep-copy a JSON-ish value, replacing the values of sensitive keys with
+ * `***`. Used before dumping API payloads to the log.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function redactSensitive<T>(value: T, depth = 0): T {
+  if (depth > 10 || value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => redactSensitive(item, depth + 1)) as unknown as T;
+  }
+
+  const result = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      result[key] = '***';
+    } else {
+      result[key] = redactSensitive(item, depth + 1);
+    }
+  }
+  return result as T;
+}

--- a/test/accessory/lockAccessory.test.ts
+++ b/test/accessory/lockAccessory.test.ts
@@ -1,0 +1,549 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import util from 'util';
+import { describe, expect, test, beforeEach, jest } from '@jest/globals';
+
+import LockAccessory from '../../src/accessory/LockAccessory';
+import TuyaDevice, { TuyaDeviceSchemaMode, TuyaDeviceSchemaType } from '../../src/device/TuyaDevice';
+import { initLogger } from '../../src/util/Logger';
+
+// HAP constants, mirroring the real values.
+const LockCurrentState = { UNSECURED: 0, SECURED: 1, JAMMED: 2, UNKNOWN: 3 };
+const LockTargetState = { UNSECURED: 0, SECURED: 1 };
+
+class MockHapStatusError extends Error {
+  constructor(public hapStatus: number) {
+    super(`HapStatusError ${hapStatus}`);
+  }
+}
+const HAPStatus = { SERVICE_COMMUNICATION_FAILURE: -70402 };
+
+describe('LockAccessory', () => {
+
+  let characteristics: Map<any, any>;
+  let services: any[];
+  let mockAccessory: any;
+  let mockPlatform: any;
+  let mockDeviceManager: any;
+  let device: TuyaDevice;
+  let logs: { level: string; message: string }[];
+
+  const makeCharacteristic = (type: any) => {
+    const characteristic: any = {
+      type,
+      value: null,
+      getHandler: undefined,
+      setHandler: undefined,
+      onGet: jest.fn((handler: any) => (characteristic.getHandler = handler, characteristic)),
+      onSet: jest.fn((handler: any) => (characteristic.setHandler = handler, characteristic)),
+      setProps: jest.fn(() => characteristic),
+      updateValue: jest.fn((value: any) => (characteristic.value = value, characteristic)),
+    };
+    characteristics.set(type, characteristic);
+    return characteristic;
+  };
+
+  const getCharacteristic = (type: any) => characteristics.get(type) || makeCharacteristic(type);
+
+  const makeService = (type: any) => {
+    const owned: any[] = [];
+    return {
+      UUID: type,
+      displayName: `${type}`,
+      subtype: undefined,
+      // `BaseAccessory.updateAllValues()` walks this array.
+      characteristics: owned,
+      getCharacteristic: jest.fn((characteristicType: any) => {
+        const characteristic = getCharacteristic(characteristicType);
+        if (!owned.includes(characteristic)) {
+          owned.push(characteristic);
+        }
+        return characteristic;
+      }),
+      setCharacteristic: jest.fn(function(this: any) {
+        return this;
+      }),
+      addOptionalCharacteristic: jest.fn(),
+      testCharacteristic: jest.fn(() => true),
+    };
+  };
+
+  /** Codes present in the schema/status of the device under test. */
+  const createDevice = (overrides: Partial<TuyaDevice> = {}) => new TuyaDevice({
+    id: 'lock-device-id',
+    uuid: 'lock-uuid',
+    name: 'Fechadura Sala de Estar',
+    online: true,
+    owner_id: 'owner-1',
+    product_id: 'ble-lock-product',
+    product_name: 'BLE Smart Lock',
+    category: 'ms',
+    sub: true,
+    schema: [
+      {
+        code: 'lock_motor_state',
+        mode: TuyaDeviceSchemaMode.READ_ONLY,
+        type: TuyaDeviceSchemaType.Boolean,
+        property: {},
+      },
+      {
+        code: 'residual_electricity',
+        mode: TuyaDeviceSchemaMode.READ_ONLY,
+        type: TuyaDeviceSchemaType.Integer,
+        property: { min: 0, max: 100, scale: 0, step: 1, unit: '%' },
+      },
+    ],
+    status: [
+      { code: 'lock_motor_state', value: false },
+      { code: 'residual_electricity', value: 80 },
+    ],
+    ...overrides,
+  } as any);
+
+  // Mirrors how homebridge renders a log line, so assertions can match the
+  // text the user actually sees.
+  const recordLog = (level: string) => (message?: any, ...args: any[]) => {
+    logs.push({ level, message: util.format(message, ...args) });
+  };
+
+  beforeEach(() => {
+    characteristics = new Map();
+    services = [];
+    logs = [];
+
+    mockDeviceManager = {
+      getDevice: jest.fn(() => device),
+      sendCommands: jest.fn(),
+      getLockTemporaryKey: jest.fn(async () => ({
+        success: true,
+        result: { ticket_id: 'TICKET-ABCDEF123456', ticket_key: 'SUPER-SECRET-KEY', expire_time: 300 },
+      })),
+      sendLockCommands: jest.fn(async () => ({ success: true, result: true })),
+      getLockRemoteUnlockMethods: jest.fn(async () => ({ success: true, result: [] })),
+    };
+
+    const hap = {
+      Service: {
+        LockMechanism: 'LockMechanism',
+        AccessoryInformation: 'AccessoryInformation',
+        Battery: 'Battery',
+      },
+      Characteristic: {
+        LockCurrentState,
+        LockTargetState,
+        StatusLowBattery: { BATTERY_LEVEL_NORMAL: 0, BATTERY_LEVEL_LOW: 1 },
+        ChargingState: { NOT_CHARGING: 0, CHARGING: 1 },
+        BatteryLevel: 'BatteryLevel',
+        StatusActive: 'StatusActive',
+        Manufacturer: 'Manufacturer',
+        Model: 'Model',
+        Name: 'Name',
+        ConfiguredName: 'ConfiguredName',
+        SerialNumber: 'SerialNumber',
+        ProgrammableSwitchEvent: { UUID: 'ProgrammableSwitchEvent' },
+      },
+      HapStatusError: MockHapStatusError,
+      HAPStatus,
+    };
+
+    mockPlatform = {
+      api: { hap },
+      Service: hap.Service,
+      Characteristic: hap.Characteristic,
+      options: { debug: true, debugLevel: '' },
+      deviceManager: mockDeviceManager,
+      getDeviceConfig: jest.fn(() => undefined),
+      getDeviceSchemaConfig: jest.fn(() => undefined),
+      log: {
+        info: recordLog('info'),
+        warn: recordLog('warn'),
+        error: recordLog('error'),
+        debug: recordLog('debug'),
+      },
+    };
+
+    // BaseAccessory builds its PrefixLogger from the module-level logger.
+    initLogger(mockPlatform.log);
+
+    mockAccessory = {
+      UUID: 'lock-uuid',
+      displayName: 'Fechadura Sala de Estar',
+      context: { deviceID: 'lock-device-id' },
+      services,
+      getService: jest.fn((type: any) => services.find(s => s.UUID === type)),
+      addService: jest.fn((type: any) => {
+        const service = makeService(type);
+        services.push(service);
+        return service;
+      }),
+      removeService: jest.fn(),
+    };
+
+    device = createDevice();
+  });
+
+  const setup = () => {
+    const accessory = new LockAccessory(mockPlatform as any, mockAccessory as any);
+    accessory.configureServices();
+    return accessory;
+  };
+
+  const targetStateCharacteristic = () => characteristics.get(LockTargetState);
+  const currentStateCharacteristic = () => characteristics.get(LockCurrentState);
+
+  const allLogText = () => logs.map(l => l.message).join('\n');
+
+  // ─── Handler registration ────────────────────────────────────────
+
+  test('registers an onSet handler on LockTargetState for a `ms` BLE lock', () => {
+    setup();
+
+    const target = targetStateCharacteristic();
+    expect(target).toBeDefined();
+    expect(target.onSet).toHaveBeenCalledTimes(1);
+    expect(typeof target.setHandler).toBe('function');
+  });
+
+  test('warns and skips LockTargetState when no writable lock dp is present', () => {
+    device = createDevice({
+      schema: [{
+        code: 'closed_opened',
+        mode: TuyaDeviceSchemaMode.READ_ONLY,
+        type: TuyaDeviceSchemaType.Boolean,
+        property: {},
+      }],
+      status: [{ code: 'closed_opened', value: false }],
+    } as any);
+
+    setup();
+
+    expect(characteristics.has(LockTargetState)).toBe(false);
+    expect(allLogText()).toContain('Remote lock/unlock from HomeKit is DISABLED');
+  });
+
+  // ─── SECURED -> UNSECURED ────────────────────────────────────────
+
+  test('SECURED -> UNSECURED runs the Smart Lock unlock flow with open=true', async () => {
+    setup();
+
+    await targetStateCharacteristic().setHandler(LockTargetState.UNSECURED);
+
+    expect(mockDeviceManager.getLockTemporaryKey).toHaveBeenCalledWith('lock-device-id');
+    expect(mockDeviceManager.sendLockCommands)
+      .toHaveBeenCalledWith('lock-device-id', 'TICKET-ABCDEF123456', true);
+  });
+
+  test('SECURED -> UNSECURED does not fall back to a raw unlock_ble dp write', async () => {
+    setup();
+
+    await targetStateCharacteristic().setHandler(LockTargetState.UNSECURED);
+
+    expect(mockDeviceManager.sendCommands).not.toHaveBeenCalled();
+  });
+
+  test('logs each step of the unlock flow', async () => {
+    setup();
+
+    await targetStateCharacteristic().setHandler(LockTargetState.UNSECURED);
+
+    const text = allLogText();
+    expect(text).toContain('HomeKit requested target state: UNSECURED');
+    expect(text).toContain('Requesting Tuya password ticket');
+    expect(text).toContain('password-ticket response');
+    expect(text).toContain('Sending door operation');
+    expect(text).toContain('open=true');
+    expect(text).toContain('door-operate response');
+  });
+
+  test('never logs the raw ticket_id or the ticket_key', async () => {
+    setup();
+
+    await targetStateCharacteristic().setHandler(LockTargetState.UNSECURED);
+
+    const text = allLogText();
+    expect(text).not.toContain('TICKET-ABCDEF123456');
+    expect(text).not.toContain('SUPER-SECRET-KEY');
+    expect(text).toContain('***3456');
+  });
+
+  // ─── getLockTemporaryKey failure ─────────────────────────────────
+
+  test('password-ticket failure aborts, logs code/msg and reports the error to HomeKit', async () => {
+    mockDeviceManager.getLockTemporaryKey.mockResolvedValue({
+      success: false, code: 1106, msg: 'permission deny',
+    } as never);
+
+    setup();
+
+    await expect(targetStateCharacteristic().setHandler(LockTargetState.UNSECURED))
+      .rejects.toBeInstanceOf(MockHapStatusError);
+
+    expect(mockDeviceManager.sendLockCommands).not.toHaveBeenCalled();
+    const text = allLogText();
+    expect(text).toContain('password-ticket failed');
+    expect(text).toContain('1106');
+    expect(text).toContain('permission deny');
+  });
+
+  test('password-ticket success without a ticket_id is treated as a failure', async () => {
+    mockDeviceManager.getLockTemporaryKey.mockResolvedValue({ success: true, result: {} } as never);
+
+    setup();
+
+    await expect(targetStateCharacteristic().setHandler(LockTargetState.UNSECURED))
+      .rejects.toBeInstanceOf(MockHapStatusError);
+    expect(mockDeviceManager.sendLockCommands).not.toHaveBeenCalled();
+  });
+
+  // ─── door-operate failure ────────────────────────────────────────
+
+  test('door-operate failure logs code/msg and reports the error to HomeKit', async () => {
+    mockDeviceManager.sendLockCommands.mockResolvedValue({
+      success: false, code: 2009, msg: 'device not support',
+    } as never);
+
+    setup();
+
+    await expect(targetStateCharacteristic().setHandler(LockTargetState.UNSECURED))
+      .rejects.toBeInstanceOf(MockHapStatusError);
+
+    const text = allLogText();
+    expect(text).toContain('door-operate failed');
+    expect(text).toContain('2009');
+    expect(text).toContain('device not support');
+  });
+
+  test('door-operate answering success=true, result=false is treated as a rejection', async () => {
+    mockDeviceManager.sendLockCommands.mockResolvedValue({ success: true, result: false } as never);
+
+    setup();
+
+    await expect(targetStateCharacteristic().setHandler(LockTargetState.UNSECURED))
+      .rejects.toBeInstanceOf(MockHapStatusError);
+    expect(allLogText()).toContain('door-operate rejected by the device');
+  });
+
+  test('a rejected door operation queries the supported remote unlocking methods', async () => {
+    mockDeviceManager.sendLockCommands.mockResolvedValue({ success: true, result: false } as never);
+    mockDeviceManager.getLockRemoteUnlockMethods.mockResolvedValue({
+      success: true, result: [{ open_type: 'ble_unlock' }],
+    } as never);
+
+    setup();
+
+    await expect(targetStateCharacteristic().setHandler(LockTargetState.UNSECURED)).rejects.toBeDefined();
+
+    expect(mockDeviceManager.getLockRemoteUnlockMethods).toHaveBeenCalledWith('lock-device-id');
+    expect(allLogText()).toContain('Remote unlocking methods reported by this lock');
+  });
+
+  // ─── Offline device ──────────────────────────────────────────────
+
+  // A BLE sub-device behind a gateway is routinely reported offline by Tuya
+  // while remote unlocking still works, so `online: false` must warn, not block.
+  test('a device Tuya reports as offline still attempts the unlock, with a warning', async () => {
+    device = createDevice({ online: false } as any);
+
+    setup();
+
+    await targetStateCharacteristic().setHandler(LockTargetState.UNSECURED);
+
+    expect(mockDeviceManager.getLockTemporaryKey).toHaveBeenCalledWith('lock-device-id');
+    expect(mockDeviceManager.sendLockCommands)
+      .toHaveBeenCalledWith('lock-device-id', 'TICKET-ABCDEF123456', true);
+    expect(allLogText()).toContain('Tuya reports this device as offline');
+  });
+
+  // ─── HTTP success must not imply an unlocked door ────────────────
+
+  test('a successful HTTP unlock does NOT mark LockCurrentState as unsecured', async () => {
+    const accessory = setup();
+
+    await targetStateCharacteristic().setHandler(LockTargetState.UNSECURED);
+
+    // The device has not reported anything yet.
+    expect(await currentStateCharacteristic().getHandler()).toBe(LockCurrentState.SECURED);
+
+    await accessory.updateAllValues();
+    expect(currentStateCharacteristic().value).toBe(LockCurrentState.SECURED);
+  });
+
+  test('LockTargetState stays on the requested value while the device has not answered', async () => {
+    setup();
+
+    await targetStateCharacteristic().setHandler(LockTargetState.UNSECURED);
+
+    expect(await targetStateCharacteristic().getHandler()).toBe(LockTargetState.UNSECURED);
+  });
+
+  test('a failed unlock releases the pending target state back to the reported one', async () => {
+    mockDeviceManager.sendLockCommands.mockResolvedValue({ success: true, result: false } as never);
+
+    setup();
+
+    await expect(targetStateCharacteristic().setHandler(LockTargetState.UNSECURED)).rejects.toBeDefined();
+
+    expect(await targetStateCharacteristic().getHandler()).toBe(LockTargetState.SECURED);
+  });
+
+  // ─── Real state arriving from the device ─────────────────────────
+
+  test('a later lock_motor_state update drives LockCurrentState', async () => {
+    const accessory = setup();
+
+    expect(await currentStateCharacteristic().getHandler()).toBe(LockCurrentState.SECURED);
+
+    // Simulate the MQTT device status update (TuyaDeviceManager mutates
+    // device.status before emitting).
+    device.status.find(s => s.code === 'lock_motor_state')!.value = true;
+    await accessory.onDeviceStatusUpdate([{ code: 'lock_motor_state', value: true }]);
+
+    expect(await currentStateCharacteristic().getHandler()).toBe(LockCurrentState.UNSECURED);
+    expect(currentStateCharacteristic().value).toBe(LockCurrentState.UNSECURED);
+    expect(allLogText()).toContain('Device reported lock_motor_state = true');
+  });
+
+  test('reaching the requested state releases the pending target state', async () => {
+    const accessory = setup();
+
+    await targetStateCharacteristic().setHandler(LockTargetState.UNSECURED);
+    expect(await targetStateCharacteristic().getHandler()).toBe(LockTargetState.UNSECURED);
+
+    device.status.find(s => s.code === 'lock_motor_state')!.value = true;
+    await accessory.onDeviceStatusUpdate([{ code: 'lock_motor_state', value: true }]);
+
+    expect(allLogText()).toContain('Releasing the pending target state');
+
+    // Once the lock relatches, HomeKit follows the device again.
+    device.status.find(s => s.code === 'lock_motor_state')!.value = false;
+    await accessory.onDeviceStatusUpdate([{ code: 'lock_motor_state', value: false }]);
+
+    expect(await targetStateCharacteristic().getHandler()).toBe(LockTargetState.SECURED);
+  });
+
+  // ─── Retry on 2312 (lock between connection windows) ─────────────
+
+  describe('retry when the lock is not reachable', () => {
+    const NOT_ONLINE = { success: false, code: 2312, msg: 'Door lock equipment is not online!' };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    });
+
+    test('a 2312 does NOT fail the HomeKit write — the retry runs behind it', async () => {
+      mockDeviceManager.sendLockCommands.mockResolvedValue(NOT_ONLINE as never);
+
+      setup();
+
+      // Must resolve: a HAP write that blocks for the whole retry window would
+      // time out on the controller regardless of what it returns.
+      await expect(targetStateCharacteristic().setHandler(LockTargetState.UNSECURED)).resolves.toBeUndefined();
+      expect(allLogText()).toContain('Retrying for up to 90s in the background');
+    });
+
+    test('keeps retrying and succeeds when the lock’s window opens', async () => {
+      mockDeviceManager.sendLockCommands
+        .mockResolvedValueOnce(NOT_ONLINE as never)
+        .mockResolvedValueOnce(NOT_ONLINE as never)
+        .mockResolvedValueOnce(NOT_ONLINE as never)
+        .mockResolvedValue({ success: true, result: true } as never);
+
+      setup();
+      await targetStateCharacteristic().setHandler(LockTargetState.UNSECURED);
+      expect(mockDeviceManager.sendLockCommands).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(40 * 1000);
+
+      expect(mockDeviceManager.sendLockCommands).toHaveBeenCalledTimes(4);
+      expect(allLogText()).toContain('Door operation accepted on retry');
+      // Every attempt carries its own ticket, since a rejected one may or may
+      // not have been consumed.
+      expect(mockDeviceManager.getLockTemporaryKey).toHaveBeenCalledTimes(4);
+    });
+
+    test('stops once the window closes and falls back to the reported state', async () => {
+      mockDeviceManager.sendLockCommands.mockResolvedValue(NOT_ONLINE as never);
+
+      setup();
+      await targetStateCharacteristic().setHandler(LockTargetState.UNSECURED);
+      expect(await targetStateCharacteristic().getHandler()).toBe(LockTargetState.UNSECURED);
+
+      await jest.advanceTimersByTimeAsync(95 * 1000);
+
+      expect(allLogText()).toContain('Gave up after 90s');
+      expect(await targetStateCharacteristic().getHandler()).toBe(LockTargetState.SECURED);
+
+      const before = mockDeviceManager.sendLockCommands.mock.calls.length;
+      await jest.advanceTimersByTimeAsync(60 * 1000);
+      expect(mockDeviceManager.sendLockCommands.mock.calls.length).toBe(before);
+    });
+
+    test('a real failure is not retried — it fails the write immediately', async () => {
+      mockDeviceManager.sendLockCommands.mockResolvedValue({
+        success: false, code: 1106, msg: 'permission deny',
+      } as never);
+
+      setup();
+      await expect(targetStateCharacteristic().setHandler(LockTargetState.UNSECURED))
+        .rejects.toBeInstanceOf(MockHapStatusError);
+
+      await jest.advanceTimersByTimeAsync(60 * 1000);
+      expect(mockDeviceManager.sendLockCommands).toHaveBeenCalledTimes(1);
+    });
+
+    test('a 2312 skips the diagnostics lookup, so retries do not spam the API', async () => {
+      mockDeviceManager.sendLockCommands.mockResolvedValue(NOT_ONLINE as never);
+
+      setup();
+      await targetStateCharacteristic().setHandler(LockTargetState.UNSECURED);
+      await jest.advanceTimersByTimeAsync(40 * 1000);
+
+      expect(mockDeviceManager.getLockRemoteUnlockMethods).not.toHaveBeenCalled();
+    });
+
+    test('the device reporting the requested state stops the retry loop', async () => {
+      mockDeviceManager.sendLockCommands.mockResolvedValue(NOT_ONLINE as never);
+
+      const accessory = setup();
+      await targetStateCharacteristic().setHandler(LockTargetState.UNSECURED);
+
+      device.status.find(s => s.code === 'lock_motor_state')!.value = true;
+      await accessory.onDeviceStatusUpdate([{ code: 'lock_motor_state', value: true }]);
+
+      const before = mockDeviceManager.sendLockCommands.mock.calls.length;
+      await jest.advanceTimersByTimeAsync(40 * 1000);
+      expect(mockDeviceManager.sendLockCommands.mock.calls.length).toBe(before);
+    });
+
+    test('a new request supersedes the one still being retried', async () => {
+      mockDeviceManager.sendLockCommands.mockResolvedValue(NOT_ONLINE as never);
+
+      setup();
+      await targetStateCharacteristic().setHandler(LockTargetState.UNSECURED);
+      await targetStateCharacteristic().setHandler(LockTargetState.SECURED);
+
+      await jest.advanceTimersByTimeAsync(25 * 1000);
+
+      // Only the newest direction is still being asked for.
+      const opens = mockDeviceManager.sendLockCommands.mock.calls.map((c: any[]) => c[2]);
+      expect(opens.slice(2).every((o: boolean) => o === false)).toBe(true);
+    });
+  });
+
+  // ─── UNSECURED -> SECURED ────────────────────────────────────────
+
+  test('UNSECURED -> SECURED sends the documented door-operate with open=false', async () => {
+    setup();
+
+    await targetStateCharacteristic().setHandler(LockTargetState.SECURED);
+
+    expect(mockDeviceManager.sendLockCommands)
+      .toHaveBeenCalledWith('lock-device-id', 'TICKET-ABCDEF123456', false);
+    expect(allLogText()).toContain('HomeKit requested target state: SECURED');
+  });
+
+});


### PR DESCRIPTION
## ♻️ Current situation

On a Bluetooth Smart Lock (category `ms`) behind a Tuya gateway, tapping Unlock in the Home app does nothing — and produces no log line anywhere.

`LockAccessory.configureLockTargetState` discards everything the Smart Lock Open Service reports:

```ts
const res = await this.deviceManager.getLockTemporaryKey(this.device.id);
if (!res.success) { return; }                    // silent abort
await this.deviceManager.sendLockCommands(this.device.id, res.result.ticket_id, open);
//  ^ no assignment — the door-operate response is dropped
```

`TuyaDeviceManager.sendLockCommands` logs nothing either, so the one leg of the flow that actually fails is the one with no observability at all. On my lock the API answers:

```json
{"success": false, "code": 2312, "msg": "Door lock equipment is not online!"}
```

That message died in an unassigned expression. `onSet` resolved normally, HomeKit recorded a success, and the door never moved. Tuya can also answer `success: true` with `result: false`, which is read as success for the same reason.

Two further bugs surfaced while instrumenting this:

- **`TuyaOpenAPI.request` never settles on a non-200.** The response handler returns without calling `resolve` or `reject`, so the promise stays pending forever — and because `retry` wraps that same promise, it never retries either. Any 4xx/5xx blocks the caller permanently, with a single `warn` as the only trace.
- **`PrefixLogger` disables masking in debug mode** (`mask = !debugMode`), which is exactly when payloads reach the log. With `debug: true` and an `api` debugLevel, the Smart Home login body — account password included — is written to `homebridge.log` in plaintext, along with access tokens and smart lock `ticket_key`s. The masking is ineffective regardless: the pre-check calls `.test()` repeatedly on `/g` regexes, whose `lastIndex` carries across calls and alternates the result.

## 💡 Proposed solution

Three commits, each passing `lint` and `build` on its own:

1. **`Keep secret masking enabled in debug mode`** — masking no longer depends on `debugMode`; the stateful-regex pre-check is dropped in favour of replacing directly (`String.replace` resets `lastIndex` itself); the key list gains `refresh_token`, `ticket_key`, `ticket_id`, `sign`. Adds `maskSecret` and `redactSensitive` to `src/util/util.ts`.
2. **`Settle the request promise on a non-200 response`** — the body is always consumed and the promise always settles, with a synthetic `success: false` response carrying the status code when the body is not JSON. Also runs the debug response dump through `redactSensitive`.
3. **`Surface Smart Lock failures, and retry when the lock is unreachable`** — step-by-step logging, failures propagated as `HapStatusError`, `2312` retried in the background, and the non-null assertions on `getStatus()` removed (they threw a `TypeError` that `updateAllValues` swallowed).

Structurally this is contained: no public API changes, no changes to other accessories. `LockAccessory` gains private state for the pending target and the retry timer; `TuyaDeviceManager` gains one method, `getLockRemoteUnlockMethods`, called only on a terminal failure. `Logger` and `TuyaOpenAPI` changes are behavioural fixes in place.

Two design points worth flagging for review:

- **`LockCurrentState` is still driven only by the reported dp.** An accepted HTTP call is not an opened door, so nothing is updated optimistically. A short-lived pending target state holds `LockTargetState` meanwhile, because `updateAllValues` otherwise snaps it back on the next status event and the Home app then declines to re-send an identical target.
- **The retry runs in the background, not inside `onSet`.** A HAP write that blocks for 90s times out on the controller regardless of what it eventually returns, so the first attempt answers and the rest runs behind it.

## ⚙️ Release Notes

Fixes remote unlocking for Tuya Smart Locks (`ms`, `jtmspro`), including Bluetooth locks behind a gateway.

- Failed unlocks now report the reason instead of silently succeeding. The Home app shows a failure rather than a lock that appears to open but does not.
- A lock that is between gateway connection windows (Tuya error `2312`) is retried for 90 seconds instead of failing on the first attempt.
- HomeKit only shows the lock as unlocked once the device reports it, not when the HTTP call returns.
- **Security:** account passwords, access tokens and smart lock ticket keys are no longer written to `homebridge.log` when `debug` is enabled. Anyone who has run this plugin with `debug: true` and an `api` debugLevel should rotate their Tuya password and delete old logs.

No breaking changes, no configuration changes.

## ➕ Additional Information

The 90-second retry window is measured, not guessed. From the lock's own connection log over six hours:

| online | offline | window | gap that follows |
|---|---|---|---|
| 19:39:51 | 19:43:39 | 3m48s | 34m42s |
| 20:18:21 | 20:19:37 | 1m16s | 19m19s |
| 20:38:56 | 20:40:08 | 1m12s | 24m34s |
| 21:04:42 | 21:06:47 | 2m05s | 72m52s |

The lock holds its gateway link for one or two minutes and drops it for twenty to seventy. A request landing in a gap is rejected with `2312`, and the lock came back online roughly 40s after a burst of four rejected attempts. Four attempts inside seven seconds caught nothing — the window is minutes, not seconds, which is why a short retry would not have helped.

Only `2312` is retried. Every other code fails immediately, so a permission or configuration error is not hidden behind 90 seconds of waiting.

### Testing

`test/accessory/lockAccessory.test.ts` is new — `LockAccessory` had no tests. 25 cases, no existing tests changed.

Covered: handler registration for `ms`; the unlock flow reaching `door-operate` with `open=true`; `password-ticket` failure; `door-operate` failure; `success: true` with `result: false`; a successful HTTP call **not** marking `LockCurrentState` as unsecured; a later `lock_motor_state` update driving it correctly; ticket ids never appearing raw in the log; a device Tuya reports as offline still being attempted; and seven cases for the retry path (write does not fail on `2312`, retry succeeds when the window opens, giving up at the deadline, real errors not retried, diagnostics not re-run per attempt, a device report cancelling the loop, a new request superseding the old one).

Known gaps: the retry tests use fake timers, so real-world timing is not exercised; the `SECURED` (remote lock) direction is covered by unit tests but I could not verify it against hardware, since my lock has no remote lock; and a status update arriving mid-retry is tested only for the requested direction.

`npx jest` reports 105 passing. `home.test.ts` and `custom.test.ts` fail identically before and after this branch — `test/util.ts` reads a `~/.homebridge-dev/config.json` that does not exist on my machine.

Verified on real hardware: unlock now works from the Home app, the `2312` retry path was exercised, and `LockCurrentState` moves only when the device reports `lock_motor_state`.

### Reviewer Nudging

Start at `src/accessory/LockAccessory.ts` — `setLockTargetState` and `performDoorOperation` are the whole story, and the `DoorOperationOutcome` type carries the design (`ok` / `unreachable` / `failed`).

The other two commits are independent and much smaller; `5e48ad0` (the unsettled promise) is four lines of real change and is worth reading first if you only read one.

Happy to split this into three PRs if you would rather review them separately — they were found in the same investigation, which is why they arrived together.
